### PR TITLE
Add ClusterClientBuilder::replica_filter to limit per-client replica fan-out

### DIFF
--- a/redis/src/cluster_handling/async_connection/mod.rs
+++ b/redis/src/cluster_handling/async_connection/mod.rs
@@ -906,7 +906,11 @@ where
                     .req_packed_command(&slot_refresh_cmd)
                     .await
                     .and_then(|value| value.extract_error())?;
-                let v: Vec<SlotRange> = parse_slots(value, addr.host())?;
+                let v: Vec<SlotRange> = parse_slots(
+                    value,
+                    addr.host(),
+                    self.cluster_params.replica_filter.as_deref(),
+                )?;
                 build_slot_map(slots, v)
             }
             .await;

--- a/redis/src/cluster_handling/client.rs
+++ b/redis/src/cluster_handling/client.rs
@@ -5,6 +5,7 @@ use crate::auth::StreamingCredentialsProvider;
 #[cfg(all(feature = "cache-aio", feature = "cluster-async"))]
 use crate::caching::{CacheConfig, CacheManager};
 use crate::client::DEFAULT_CONNECTION_TIMEOUT;
+use crate::cluster_handling::NodeAddress;
 use crate::cluster_handling::read_routing::{RandomReplicaStrategy, ReadRoutingStrategyFactory};
 use crate::connection::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo};
 use crate::errors::{ErrorKind, RedisError};
@@ -46,6 +47,7 @@ struct BuilderParams {
     password: Option<ArcStr>,
     username: Option<ArcStr>,
     read_routing_factory: Option<Arc<dyn ReadRoutingStrategyFactory>>,
+    replica_filter: Option<Arc<dyn Fn(&NodeAddress) -> bool + Send + Sync>>,
     tls: Option<TlsMode>,
     #[cfg(feature = "tls-rustls")]
     certs: Option<TlsCertificates>,
@@ -113,6 +115,7 @@ pub(crate) struct ClusterParams {
     pub(crate) password: Option<ArcStr>,
     pub(crate) username: Option<ArcStr>,
     pub(crate) read_routing_factory: Option<Arc<dyn ReadRoutingStrategyFactory>>,
+    pub(crate) replica_filter: Option<Arc<dyn Fn(&NodeAddress) -> bool + Send + Sync>>,
     /// tls indicates tls behavior of connections.
     /// When Some(TlsMode), connections use tls and verify certification depends on TlsMode.
     /// When None, connections do not use tls.
@@ -174,6 +177,7 @@ impl ClusterParams {
             password: value.password,
             username: value.username,
             read_routing_factory: value.read_routing_factory,
+            replica_filter: value.replica_filter,
             tls: value.tls,
             retry_params: value.retries_configuration,
             tls_params,
@@ -497,6 +501,55 @@ impl ClusterClientBuilder {
         strategy: impl ReadRoutingStrategyFactory + 'static,
     ) -> ClusterClientBuilder {
         self.builder_params.read_routing_factory = Some(Arc::new(strategy));
+        self
+    }
+
+    /// Restricts which replicas this client connects to.
+    ///
+    /// By default, `ClusterClient` opens a TCP connection to every node returned by
+    /// `CLUSTER SLOTS` — the primary plus every replica of every shard. For
+    /// deployments with many replicas per shard, this can overwhelm the cluster as
+    /// each application instance multiplies the connection fan-out.
+    ///
+    /// The supplied predicate is called once per replica each time the topology is
+    /// (re)discovered. Returning `true` keeps the replica; returning `false` drops
+    /// it before the slot map is built, so the client never opens a connection to
+    /// it and the [`ReadRoutingStrategy`](crate::cluster_read_routing::ReadRoutingStrategy)
+    /// never sees it. Primaries are never passed to the filter.
+    ///
+    /// If the filter drops every replica of a shard, reads for that shard fall back
+    /// to the primary, just as if the shard had no replicas.
+    ///
+    /// To deterministically partition replicas across multiple client instances
+    /// without coordination, hash the [`NodeAddress`] and assign by modulo:
+    ///
+    /// ```rust,no_run
+    /// use redis::cluster::{ClusterClientBuilder, NodeAddress};
+    /// use std::hash::{BuildHasher, Hasher, RandomState};
+    ///
+    /// // This instance owns shard 2 of 4.
+    /// let shard_id: u64 = 2;
+    /// let shard_count: u64 = 4;
+    /// let hasher = RandomState::new();
+    ///
+    /// let client = ClusterClientBuilder::new(vec!["redis://127.0.0.1:6379/"])
+    ///     .replica_filter(move |addr: &NodeAddress| {
+    ///         let mut h = hasher.build_hasher();
+    ///         h.write(addr.host().as_bytes());
+    ///         h.write_u16(addr.port());
+    ///         h.finish() % shard_count == shard_id
+    ///     })
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    ///
+    /// Note: use a stable hasher (not `RandomState`) if you need the same client
+    /// to pick the same replicas across restarts.
+    pub fn replica_filter<F>(mut self, filter: F) -> ClusterClientBuilder
+    where
+        F: Fn(&NodeAddress) -> bool + Send + Sync + 'static,
+    {
+        self.builder_params.replica_filter = Some(Arc::new(filter));
         self
     }
 
@@ -924,6 +977,29 @@ mod tests {
     fn connection_concurrency_limit_default() {
         let client = ClusterClient::new(get_connection_data()).unwrap();
         assert_eq!(client.cluster_params.connection_concurrency_limit, None);
+    }
+
+    #[test]
+    fn replica_filter_default_is_none() {
+        let client = ClusterClient::new(get_connection_data()).unwrap();
+        assert!(client.cluster_params.replica_filter.is_none());
+    }
+
+    #[test]
+    fn replica_filter_is_stored() {
+        let client = ClusterClientBuilder::new(get_connection_data())
+            .replica_filter(|addr| addr.port() == 6379)
+            .build()
+            .unwrap();
+        let filter = client
+            .cluster_params
+            .replica_filter
+            .as_ref()
+            .expect("filter should be set");
+        let kept = super::NodeAddress::new("h", 6379);
+        let dropped = super::NodeAddress::new("h", 6380);
+        assert!(filter(&kept));
+        assert!(!filter(&dropped));
     }
 
     #[cfg(feature = "cluster-async")]

--- a/redis/src/cluster_handling/client.rs
+++ b/redis/src/cluster_handling/client.rs
@@ -7,6 +7,12 @@ use crate::caching::{CacheConfig, CacheManager};
 use crate::client::DEFAULT_CONNECTION_TIMEOUT;
 use crate::cluster_handling::NodeAddress;
 use crate::cluster_handling::read_routing::{RandomReplicaStrategy, ReadRoutingStrategyFactory};
+
+/// A predicate that decides which replicas a `ClusterClient` connects to.
+///
+/// Returning `true` keeps the replica; `false` drops it before it enters the
+/// slot map. See [`ClusterClientBuilder::replica_filter`].
+pub type ReplicaFilter = dyn Fn(&NodeAddress) -> bool + Send + Sync;
 use crate::connection::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo};
 use crate::errors::{ErrorKind, RedisError};
 #[cfg(feature = "cluster-async")]
@@ -47,7 +53,7 @@ struct BuilderParams {
     password: Option<ArcStr>,
     username: Option<ArcStr>,
     read_routing_factory: Option<Arc<dyn ReadRoutingStrategyFactory>>,
-    replica_filter: Option<Arc<dyn Fn(&NodeAddress) -> bool + Send + Sync>>,
+    replica_filter: Option<Arc<ReplicaFilter>>,
     tls: Option<TlsMode>,
     #[cfg(feature = "tls-rustls")]
     certs: Option<TlsCertificates>,
@@ -115,7 +121,7 @@ pub(crate) struct ClusterParams {
     pub(crate) password: Option<ArcStr>,
     pub(crate) username: Option<ArcStr>,
     pub(crate) read_routing_factory: Option<Arc<dyn ReadRoutingStrategyFactory>>,
-    pub(crate) replica_filter: Option<Arc<dyn Fn(&NodeAddress) -> bool + Send + Sync>>,
+    pub(crate) replica_filter: Option<Arc<ReplicaFilter>>,
     /// tls indicates tls behavior of connections.
     /// When Some(TlsMode), connections use tls and verify certification depends on TlsMode.
     /// When None, connections do not use tls.

--- a/redis/src/cluster_handling/sync_connection/mod.rs
+++ b/redis/src/cluster_handling/sync_connection/mod.rs
@@ -508,7 +508,11 @@ where
 
         for (addr, conn) in connections.iter_mut() {
             let value = conn.req_command(&slot_cmd())?;
-            if let Ok(slots_data) = parse_slots(value, addr.host()) {
+            if let Ok(slots_data) = parse_slots(
+                value,
+                addr.host(),
+                self.cluster_params.replica_filter.as_deref(),
+            ) {
                 new_slots = Some(SlotMap::from_slots(slots_data));
                 break;
             }

--- a/redis/src/cluster_handling/topology.rs
+++ b/redis/src/cluster_handling/topology.rs
@@ -8,11 +8,18 @@ use super::NodeAddress;
 use super::slot_map::SlotRange;
 use crate::{RedisResult, Value, connection::is_wildcard_address};
 
+/// A predicate that decides which replicas should be kept in the topology.
+///
+/// Returning `true` keeps the replica; `false` drops it. Primaries are never
+/// passed to this predicate (filtering a primary would break slot routing).
+pub(crate) type ReplicaFilter = dyn Fn(&super::NodeAddress) -> bool + Send + Sync;
+
 // Parse slot data from raw redis value.
 pub(crate) fn parse_slots(
     raw_slot_resp: Value,
     // The DNS address of the node from which `raw_slot_resp` was received.
     addr_of_answering_node: &str,
+    replica_filter: Option<&ReplicaFilter>,
 ) -> RedisResult<Vec<SlotRange>> {
     // Parse response.
     let mut slots = Vec::with_capacity(2);
@@ -93,7 +100,10 @@ pub(crate) fn parse_slots(
             let Some(primary) = primary else {
                 continue;
             };
-            let replicas: Vec<NodeAddress> = iterator.filter_map(try_to_address).collect();
+            let replicas: Vec<NodeAddress> = iterator
+                .filter_map(try_to_address)
+                .filter(|addr| replica_filter.is_none_or(|f| f(addr)))
+                .collect();
 
             slots.push(SlotRange::new(start, end, primary, replicas));
         }
@@ -129,7 +139,7 @@ mod tests {
     fn parse_slots_returns_slots_with_host_name_if_missing() {
         let view = Value::Array(vec![slot_value(0, 4000, "", 6379)]);
 
-        let slots = parse_slots(view, "node").unwrap();
+        let slots = parse_slots(view, "node", None).unwrap();
         assert_eq!(slots[0].master, "node:6379");
     }
 
@@ -141,12 +151,45 @@ mod tests {
             100,
             vec![("0.0.0.0", 7000)],
         )]);
-        let slots = parse_slots(view, "answer.host").unwrap();
+        let slots = parse_slots(view, "answer.host", None).unwrap();
         assert_eq!(slots[0].master, "answer.host:7000");
 
         // IPv6 wildcard :: similarly falls back to answering node
         let view_v6 = Value::Array(vec![slot_value_with_replicas(200, 300, vec![("::", 7001)])]);
-        let slots_v6 = parse_slots(view_v6, "answer6.host").unwrap();
+        let slots_v6 = parse_slots(view_v6, "answer6.host", None).unwrap();
         assert_eq!(slots_v6[0].master, "answer6.host:7001");
+    }
+
+    #[test]
+    fn parse_slots_applies_replica_filter() {
+        // Shard: primary "p:6379" + replicas "r1:6379", "r2:6379", "r3:6379"
+        let view = Value::Array(vec![slot_value_with_replicas(
+            0,
+            100,
+            vec![("p", 6379), ("r1", 6379), ("r2", 6379), ("r3", 6379)],
+        )]);
+
+        // Keep only "r2" — primary must pass through untouched.
+        let keep_r2 = |addr: &NodeAddress| addr.host() == "r2";
+        let slots = parse_slots(view, "answer", Some(&keep_r2)).unwrap();
+
+        assert_eq!(slots[0].master, "p:6379");
+        assert_eq!(slots[0].replicas.len(), 1);
+        assert_eq!(slots[0].replicas[0], "r2:6379");
+    }
+
+    #[test]
+    fn parse_slots_filter_dropping_all_replicas_leaves_primary() {
+        let view = Value::Array(vec![slot_value_with_replicas(
+            0,
+            100,
+            vec![("p", 6379), ("r1", 6379), ("r2", 6379)],
+        )]);
+
+        let drop_all = |_addr: &NodeAddress| false;
+        let slots = parse_slots(view, "answer", Some(&drop_all)).unwrap();
+
+        assert_eq!(slots[0].master, "p:6379");
+        assert!(slots[0].replicas.is_empty());
     }
 }

--- a/redis/src/cluster_handling/topology.rs
+++ b/redis/src/cluster_handling/topology.rs
@@ -8,18 +8,12 @@ use super::NodeAddress;
 use super::slot_map::SlotRange;
 use crate::{RedisResult, Value, connection::is_wildcard_address};
 
-/// A predicate that decides which replicas should be kept in the topology.
-///
-/// Returning `true` keeps the replica; `false` drops it. Primaries are never
-/// passed to this predicate (filtering a primary would break slot routing).
-pub(crate) type ReplicaFilter = dyn Fn(&super::NodeAddress) -> bool + Send + Sync;
-
 // Parse slot data from raw redis value.
 pub(crate) fn parse_slots(
     raw_slot_resp: Value,
     // The DNS address of the node from which `raw_slot_resp` was received.
     addr_of_answering_node: &str,
-    replica_filter: Option<&ReplicaFilter>,
+    replica_filter: Option<&super::client::ReplicaFilter>,
 ) -> RedisResult<Vec<SlotRange>> {
     // Parse response.
     let mut slots = Vec::with_capacity(2);


### PR DESCRIPTION
## Summary

- Adds `ClusterClientBuilder::replica_filter(impl Fn(&NodeAddress) -> bool)`.
- The predicate runs once per replica each time topology is (re)discovered. Replicas it drops never enter the slot map, so the client opens no TCP connection to them and the `ReadRoutingStrategy` never sees them.
- Primaries are never passed to the filter. When every replica of a shard is filtered out, reads for that shard fall back to the primary (same behavior as a shard with no replicas).

## Motivation

`ClusterConnection` eagerly opens a TCP connection to every node returned by `CLUSTER SLOTS`. In deployments with many replicas per shard, each application instance multiplies that fan-out and can overwhelm the cluster. This option lets each client own a subset of replicas — e.g. by hashing `NodeAddress` and assigning by modulo — so the connection load can be split across instances without coordination. Doc example included on the builder method.

## Implementation

- New `replica_filter: Option<Arc<dyn Fn(&NodeAddress) -> bool + Send + Sync>>` field on `BuilderParams` / `ClusterParams`.
- Threaded through to `topology::parse_slots`, which applies it to each replica list before constructing `SlotRange`s. Single place handles both sync and async paths.
- Existing call sites in `cluster_async` and `cluster` pass `cluster_params.replica_filter.as_deref()`.

## Test plan

- [x] `cargo check -p redis --no-default-features --features 'cluster cluster-async tokio-comp'`
- [x] `cargo clippy --no-deps --keep-going --workspace ... -- -Dwarnings` (matches CI invocation)
- [x] `cargo test -p redis --lib cluster_handling` — 67 passed (incl. new tests `parse_slots_applies_replica_filter`, `parse_slots_filter_dropping_all_replicas_leaves_primary`, `replica_filter_default_is_none`, `replica_filter_is_stored`)
- [ ] Integration test against a multi-replica cluster (not run locally)

---

Claude session: C07609CD-8086-41C3-8D60-4E65E07BD041