### PR TITLE
Add Redis cluster connection diagnostics

### DIFF
--- a/redis/src/cluster_handling/async_connection/mod.rs
+++ b/redis/src/cluster_handling/async_connection/mod.rs
@@ -1555,6 +1555,15 @@ where
     let mut readonly_cmd = cmd("READONLY");
     readonly_cmd.skip_concurrency_limit = true;
     conn.req_packed_command(&readonly_cmd).await?;
+    if let Some(factory) = &params.client_name_factory {
+        let name = factory(node);
+        if !name.is_empty() {
+            let mut setname_cmd = cmd("CLIENT");
+            setname_cmd.arg("SETNAME").arg(name);
+            setname_cmd.skip_concurrency_limit = true;
+            let _ = conn.req_packed_command(&setname_cmd).await;
+        }
+    }
     Ok(conn)
 }
 

--- a/redis/src/cluster_handling/client.rs
+++ b/redis/src/cluster_handling/client.rs
@@ -13,6 +13,13 @@ use crate::cluster_handling::read_routing::{RandomReplicaStrategy, ReadRoutingSt
 /// Returning `true` keeps the replica; `false` drops it before it enters the
 /// slot map. See [`ClusterClientBuilder::replica_filter`].
 pub type ReplicaFilter = dyn Fn(&NodeAddress) -> bool + Send + Sync;
+
+/// Builds the Redis client name for each cluster node connection.
+///
+/// The factory is called whenever the client opens a node connection. Returning
+/// a stable, low-cardinality name makes `CLIENT LIST` useful for debugging
+/// application-side connection fanout.
+pub type ClientNameFactory = dyn Fn(&NodeAddress) -> String + Send + Sync;
 use crate::connection::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo};
 use crate::errors::{ErrorKind, RedisError};
 #[cfg(feature = "cluster-async")]
@@ -122,6 +129,7 @@ pub(crate) struct ClusterParams {
     pub(crate) username: Option<ArcStr>,
     pub(crate) read_routing_factory: Option<Arc<dyn ReadRoutingStrategyFactory>>,
     pub(crate) replica_filter: Option<Arc<ReplicaFilter>>,
+    pub(crate) client_name_factory: Option<Arc<ClientNameFactory>>,
     /// tls indicates tls behavior of connections.
     /// When Some(TlsMode), connections use tls and verify certification depends on TlsMode.
     /// When None, connections do not use tls.
@@ -184,6 +192,7 @@ impl ClusterParams {
             username: value.username,
             read_routing_factory: value.read_routing_factory,
             replica_filter: value.replica_filter,
+            client_name_factory: None,
             tls: value.tls,
             retry_params: value.retries_configuration,
             tls_params,
@@ -226,6 +235,8 @@ impl ClusterParams {
         if let Some(async_dns_resolver) = config.async_dns_resolver {
             self.async_dns_resolver = Some(async_dns_resolver);
         }
+
+        self.client_name_factory = config.client_name_factory;
 
         self
     }
@@ -805,6 +816,20 @@ impl ClusterClient {
     }
 
     #[doc(hidden)]
+    pub fn get_generic_connection_with_config<C>(
+        &self,
+        config: cluster::ClusterConfig,
+    ) -> RedisResult<cluster::ClusterConnection<C>>
+    where
+        C: crate::ConnectionLike + crate::cluster::Connect + Send,
+    {
+        cluster::ClusterConnection::new(
+            self.cluster_params.clone().with_config(config),
+            self.initial_nodes.clone(),
+        )
+    }
+
+    #[doc(hidden)]
     #[cfg(feature = "cluster-async")]
     pub async fn get_async_generic_connection<C>(
         &self,
@@ -826,6 +851,7 @@ impl ClusterClient {
 #[cfg(test)]
 mod tests {
     use super::{ClusterClient, ClusterClientBuilder, ConnectionInfo, IntoConnectionInfo};
+    #[cfg(feature = "cluster-async")]
     use std::time::Duration;
 
     fn get_connection_data() -> Vec<ConnectionInfo> {

--- a/redis/src/cluster_handling/sync_connection/mod.rs
+++ b/redis/src/cluster_handling/sync_connection/mod.rs
@@ -64,6 +64,7 @@
 //! ```
 use std::cell::RefCell;
 use std::collections::HashSet;
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
@@ -231,6 +232,7 @@ impl Connect for Connection {
 pub struct ClusterConfig {
     pub(crate) connection_timeout: Option<Duration>,
     pub(crate) response_timeout: Option<Duration>,
+    pub(crate) client_name_factory: Option<Arc<super::client::ClientNameFactory>>,
     #[cfg(feature = "cluster-async")]
     pub(crate) async_push_sender: Option<std::sync::Arc<dyn crate::aio::AsyncPushSender>>,
     #[cfg(feature = "cluster-async")]
@@ -252,6 +254,20 @@ impl ClusterConfig {
     /// Sets the response timeout
     pub fn set_response_timeout(mut self, response_timeout: std::time::Duration) -> Self {
         self.response_timeout = Some(response_timeout);
+        self
+    }
+
+    /// Sets a factory that builds a Redis client name for each cluster node
+    /// connection opened by this `ClusterConnection`.
+    ///
+    /// The name is sent with `CLIENT SETNAME` after the connection enters
+    /// cluster-read mode. Errors are ignored so naming never prevents a usable
+    /// connection from being established.
+    pub fn set_client_name_factory(
+        mut self,
+        factory: impl Fn(&NodeAddress) -> String + Send + Sync + 'static,
+    ) -> Self {
+        self.client_name_factory = Some(Arc::new(factory));
         self
     }
 
@@ -308,6 +324,30 @@ pub struct ClusterConnection<C = Connection> {
     write_timeout: RefCell<Option<Duration>>,
     routing_strategy: Option<Box<dyn ReadRoutingStrategy>>,
     cluster_params: ClusterParams,
+}
+
+impl<C> ClusterConnection<C> {
+    /// Returns the node addresses that currently have open connections.
+    ///
+    /// This method is intended for diagnostics and tests. The result is a
+    /// moment-in-time snapshot and should not be used for routing decisions.
+    #[doc(hidden)]
+    pub fn connected_node_addresses(&self) -> Vec<NodeAddress> {
+        let mut addrs = self
+            .connections
+            .borrow()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        addrs.sort_unstable();
+        addrs
+    }
+
+    /// Returns the number of node connections currently held by this cluster connection.
+    #[doc(hidden)]
+    pub fn connected_node_count(&self) -> usize {
+        self.connections.borrow().len()
+    }
 }
 
 /// Upper bound on the number of worker threads used to open node connections
@@ -1198,9 +1238,25 @@ fn connect_node<C: ConnectionLike + Connect>(
     // We set this unconditionally, because we don't know whether we'll be making read calls
     // to replicas. (We allow overriding routing per-call)
     cmd("READONLY").exec(&mut conn)?;
+    set_client_name(&mut conn, node, cluster_params);
     conn.set_read_timeout(read_timeout)?;
     conn.set_write_timeout(write_timeout)?;
     Ok(conn)
+}
+
+fn set_client_name<C: ConnectionLike>(
+    conn: &mut C,
+    node: &NodeAddress,
+    cluster_params: &ClusterParams,
+) {
+    let Some(factory) = &cluster_params.client_name_factory else {
+        return;
+    };
+    let name = factory(node);
+    if name.is_empty() {
+        return;
+    }
+    let _ = cmd("CLIENT").arg("SETNAME").arg(name).exec(conn);
 }
 
 fn get_random_connection<C: ConnectionLike + Connect + Sized>(

--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -318,6 +318,20 @@ impl MockEnv {
         id: &str,
         handler: impl Fn(&[u8], u16) -> Result<(), RedisResult<Value>> + Send + Sync + 'static,
     ) -> Self {
+        Self::with_client_builder_and_config(
+            client_builder,
+            redis::cluster::ClusterConfig::new(),
+            id,
+            handler,
+        )
+    }
+
+    pub fn with_client_builder_and_config(
+        client_builder: ClusterClientBuilder,
+        connection_config: redis::cluster::ClusterConfig,
+        id: &str,
+        handler: impl Fn(&[u8], u16) -> Result<(), RedisResult<Value>> + Send + Sync + 'static,
+    ) -> Self {
         #[cfg(feature = "cluster-async")]
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_io()
@@ -332,7 +346,9 @@ impl MockEnv {
             .insert(id.clone(), Arc::new(move |cmd, port| handler(cmd, port)));
 
         let client = client_builder.build().unwrap();
-        let connection = client.get_generic_connection().unwrap();
+        let connection = client
+            .get_generic_connection_with_config(connection_config)
+            .unwrap();
         #[cfg(feature = "cluster-async")]
         let async_connection = runtime
             .block_on(client.get_async_generic_connection())

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -640,6 +640,150 @@ mod cluster {
     }
 
     #[test]
+    fn test_cluster_connected_node_addresses_respect_replica_filter() {
+        let name = "test_cluster_connected_node_addresses_respect_replica_filter";
+        let slots_config = vec![
+            MockSlotRange {
+                primary_port: 6379,
+                replica_ports: vec![6380, 6381],
+                slot_range: 0..8192,
+            },
+            MockSlotRange {
+                primary_port: 6382,
+                replica_ports: vec![6383, 6384],
+                slot_range: 8192..16384,
+            },
+        ];
+
+        let MockEnv { connection, .. } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .replica_filter(|addr| matches!(addr.port(), 6380 | 6384)),
+            name,
+            move |cmd: &[u8], _port| {
+                respond_startup_with_replica_using_config(name, cmd, Some(slots_config.clone()))
+            },
+        );
+
+        let ports = connection
+            .connected_node_addresses()
+            .into_iter()
+            .map(|addr| addr.port())
+            .collect::<Vec<_>>();
+        assert_eq!(ports, vec![6379, 6380, 6382, 6384]);
+        assert_eq!(connection.connected_node_count(), 4);
+    }
+
+    #[test]
+    fn test_cluster_client_name_factory_names_each_connected_node() {
+        let name = "test_cluster_client_name_factory_names_each_connected_node";
+        let slots_config = vec![
+            MockSlotRange {
+                primary_port: 6379,
+                replica_ports: vec![6380],
+                slot_range: 0..8192,
+            },
+            MockSlotRange {
+                primary_port: 6381,
+                replica_ports: vec![6382],
+                slot_range: 8192..16384,
+            },
+        ];
+        let seen = Arc::new(std::sync::Mutex::new(Vec::<(u16, String)>::new()));
+        let seen_for_handler = seen.clone();
+
+        let _env = MockEnv::with_client_builder_and_config(
+            ClusterClient::builder(vec![&*format!("redis://{name}")]),
+            redis::cluster::ClusterConfig::new()
+                .set_client_name_factory(|addr| format!("mock-client-{}", addr.port())),
+            name,
+            move |cmd: &[u8], port| {
+                if contains_slice(cmd, b"CLIENT") && contains_slice(cmd, b"SETNAME") {
+                    seen_for_handler
+                        .lock()
+                        .unwrap()
+                        .push((port, String::from_utf8_lossy(cmd).into_owned()));
+                    return Err(Ok(redis_value!(simple:"OK")));
+                }
+                respond_startup_with_replica_using_config(name, cmd, Some(slots_config.clone()))
+            },
+        );
+
+        let mut seen = seen.lock().unwrap().clone();
+        seen.sort_by_key(|(port, _)| *port);
+        assert_eq!(
+            seen.iter().map(|(port, _)| *port).collect::<Vec<_>>(),
+            vec![6379, 6380, 6381, 6382]
+        );
+        for (port, cmd) in seen {
+            assert!(cmd.contains(&format!("mock-client-{port}")));
+        }
+    }
+
+    #[test]
+    fn test_cluster_client_name_factory_names_new_nodes_after_refresh() {
+        let name = "test_cluster_client_name_factory_names_new_nodes_after_refresh";
+        let requests = atomic::AtomicUsize::new(0);
+        let started = atomic::AtomicBool::new(false);
+        let seen = Arc::new(std::sync::Mutex::new(Vec::<(u16, String)>::new()));
+        let seen_for_handler = seen.clone();
+
+        let MockEnv {
+            mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder_and_config(
+            ClusterClient::builder(vec![&*format!("redis://{name}")]),
+            redis::cluster::ClusterConfig::new()
+                .set_client_name_factory(|addr| format!("mock-client-{}", addr.port())),
+            name,
+            move |cmd: &[u8], port| {
+                if contains_slice(cmd, b"CLIENT") && contains_slice(cmd, b"SETNAME") {
+                    seen_for_handler
+                        .lock()
+                        .unwrap()
+                        .push((port, String::from_utf8_lossy(cmd).into_owned()));
+                    return Err(Ok(redis_value!(simple:"OK")));
+                }
+
+                if !started.load(atomic::Ordering::SeqCst) {
+                    respond_startup(name, cmd)?;
+                }
+                started.store(true, atomic::Ordering::SeqCst);
+
+                if is_connection_check(cmd) {
+                    return Err(Ok(redis_value!(simple:"OK")));
+                }
+
+                let i = requests.fetch_add(1, atomic::Ordering::SeqCst);
+                match i {
+                    0 => Err(parse_redis_value(b"-MOVED 123\r\n")),
+                    1 => Err(Ok(redis_value!([
+                        [0, 1, [name, 6379]],
+                        [2, 16383, [name, 6380]]
+                    ]))),
+                    _ => {
+                        assert_eq!(port, 6380);
+                        Err(Ok(redis_value!("123")))
+                    }
+                }
+            },
+        );
+
+        let value = cmd("GET").arg("test").query::<Option<i32>>(&mut connection);
+        assert_eq!(value, Ok(Some(123)));
+
+        let mut seen = seen.lock().unwrap().clone();
+        seen.sort_by_key(|(port, _)| *port);
+        assert_eq!(
+            seen.iter().map(|(port, _)| *port).collect::<Vec<_>>(),
+            vec![6379, 6380]
+        );
+        for (port, cmd) in seen {
+            assert!(cmd.contains(&format!("mock-client-{port}")));
+        }
+    }
+
+    #[test]
     fn test_cluster_round_robin_read() {
         let name = "test_cluster_round_robin_read";
         let ports = Arc::new(std::sync::Mutex::new(Vec::new()));

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -674,6 +674,39 @@ mod cluster {
     }
 
     #[test]
+    fn test_cluster_replica_filter_drop_all_connects_primaries_only() {
+        let name = "test_cluster_replica_filter_drop_all_connects_primaries_only";
+        let slots_config = vec![
+            MockSlotRange {
+                primary_port: 6379,
+                replica_ports: vec![6380, 6381],
+                slot_range: 0..8192,
+            },
+            MockSlotRange {
+                primary_port: 6382,
+                replica_ports: vec![6383, 6384],
+                slot_range: 8192..16384,
+            },
+        ];
+
+        let MockEnv { connection, .. } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")]).replica_filter(|_addr| false),
+            name,
+            move |cmd: &[u8], _port| {
+                respond_startup_with_replica_using_config(name, cmd, Some(slots_config.clone()))
+            },
+        );
+
+        let ports = connection
+            .connected_node_addresses()
+            .into_iter()
+            .map(|addr| addr.port())
+            .collect::<Vec<_>>();
+        assert_eq!(ports, vec![6379, 6382]);
+        assert_eq!(connection.connected_node_count(), 2);
+    }
+
+    #[test]
     fn test_cluster_client_name_factory_names_each_connected_node() {
         let name = "test_cluster_client_name_factory_names_each_connected_node";
         let slots_config = vec![


### PR DESCRIPTION
Labels: redis, bugfix, performance

Adds a per-node client name factory to cluster connection configuration and exposes doc-hidden connected-node diagnostics for sync cluster connections. CLIENT SETNAME is applied best-effort after READONLY for sync and async node creation, including topology refreshes.

This lets Redis Lightning prove which Redis nodes each outer pooled cluster connection actually opens sockets to, and it adds coverage that a deny-all replica filter connects only to primaries even when CLUSTER SLOTS advertises replicas.

No new environment variables are introduced.

Validated locally with `cargo fmt -p redis` and `cargo test -p redis --features cluster replica_filter`.
