### PR TITLE
[codex] Benchmark zonal read routing

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -235,6 +235,11 @@ harness = false
 required-features = ["cluster"]
 
 [[bench]]
+name = "bench_cluster_read_routing"
+harness = false
+required-features = ["cluster"]
+
+[[bench]]
 name = "bench_cluster_async"
 harness = false
 required-features = ["cluster-async", "tokio-comp"]

--- a/redis/benches/bench_cluster_read_routing.rs
+++ b/redis/benches/bench_cluster_read_routing.rs
@@ -1,0 +1,198 @@
+#![cfg(feature = "cluster")]
+
+use std::hint::black_box;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use redis::cluster::ClusterClient;
+use redis::cluster_read_routing::{
+    RandomReplicaStrategy, RoundRobinReplicaStrategy, ZonalReadRoutingStrategy,
+};
+use redis::{Value, cmd};
+
+use support::{
+    MockEnv, MockSlotRange, contains_slice, is_connection_check,
+    respond_startup_with_replica_using_config,
+};
+
+#[allow(dead_code)]
+#[path = "../tests/support/mock_cluster.rs"]
+mod support;
+
+fn slots_config() -> Vec<MockSlotRange> {
+    vec![
+        MockSlotRange {
+            primary_port: 6379,
+            replica_ports: vec![6380, 6381],
+            slot_range: 0..4095,
+        },
+        MockSlotRange {
+            primary_port: 6382,
+            replica_ports: vec![6383, 6384],
+            slot_range: 4096..8191,
+        },
+        MockSlotRange {
+            primary_port: 6385,
+            replica_ports: vec![6386, 6387],
+            slot_range: 8192..12287,
+        },
+        MockSlotRange {
+            primary_port: 6388,
+            replica_ports: vec![6389, 6390],
+            slot_range: 12288..16383,
+        },
+    ]
+}
+
+fn zones() -> Vec<(u16, &'static str)> {
+    vec![
+        (6379, "us-east-1a"),
+        (6380, "us-east-1b"),
+        (6381, "us-east-1c"),
+        (6382, "us-east-1a"),
+        (6383, "us-east-1b"),
+        (6384, "us-east-1c"),
+        (6385, "us-east-1a"),
+        (6386, "us-east-1c"),
+        (6387, "us-east-1d"),
+        (6388, "us-east-1a"),
+        (6389, "us-east-1b"),
+        (6390, "us-east-1b"),
+    ]
+}
+
+fn bulk(value: &str) -> Value {
+    Value::BulkString(value.as_bytes().to_vec())
+}
+
+fn cluster_shards_with_zones(
+    name: &str,
+    slots_config: &[MockSlotRange],
+    zones: &[(u16, &str)],
+) -> Value {
+    let zone_for_port = |port| {
+        zones
+            .iter()
+            .find_map(|(candidate_port, zone)| (*candidate_port == port).then_some(*zone))
+            .unwrap_or("unknown-zone")
+    };
+
+    Value::Array(
+        slots_config
+            .iter()
+            .map(|slot| {
+                let mut nodes = vec![Value::Map(vec![
+                    (bulk("endpoint"), bulk(name)),
+                    (bulk("port"), Value::Int(slot.primary_port as i64)),
+                    (
+                        bulk("availability-zone"),
+                        bulk(zone_for_port(slot.primary_port)),
+                    ),
+                ])];
+                nodes.extend(slot.replica_ports.iter().map(|port| {
+                    Value::Map(vec![
+                        (bulk("endpoint"), bulk(name)),
+                        (bulk("port"), Value::Int(*port as i64)),
+                        (bulk("availability-zone"), bulk(zone_for_port(*port))),
+                    ])
+                }));
+
+                Value::Map(vec![
+                    (
+                        bulk("slots"),
+                        Value::Array(vec![
+                            Value::Int(slot.slot_range.start as i64),
+                            Value::Int(slot.slot_range.end as i64),
+                        ]),
+                    ),
+                    (bulk("nodes"), Value::Array(nodes)),
+                ])
+            })
+            .collect(),
+    )
+}
+
+fn mock_env(name: &'static str, builder: redis::cluster::ClusterClientBuilder) -> MockEnv {
+    let slots_config = slots_config();
+    let zones = zones();
+
+    MockEnv::with_client_builder(builder, name, move |packed_command: &[u8], _port| {
+        if is_connection_check(packed_command) {
+            return Err(Ok(Value::SimpleString("OK".into())));
+        }
+        if contains_slice(packed_command, b"CLUSTER") && contains_slice(packed_command, b"SLOTS") {
+            return respond_startup_with_replica_using_config(
+                name,
+                packed_command,
+                Some(slots_config.clone()),
+            );
+        }
+        if contains_slice(packed_command, b"CLUSTER") && contains_slice(packed_command, b"SHARDS") {
+            return Err(Ok(cluster_shards_with_zones(name, &slots_config, &zones)));
+        }
+        if contains_slice(packed_command, b"GET") {
+            return Err(Ok(Value::BulkString(b"123".to_vec())));
+        }
+        Ok(())
+    })
+}
+
+fn bench_get(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    name: &'static str,
+    builder: redis::cluster::ClusterClientBuilder,
+) {
+    let mut env = mock_env(name, builder);
+    group.bench_function(name, |b| {
+        b.iter(|| {
+            let value: Option<i32> = cmd("GET")
+                .arg(black_box("{bench}key"))
+                .query(&mut env.connection)
+                .unwrap();
+            black_box(value)
+        });
+    });
+}
+
+fn bench_cluster_read_routing(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cluster_read_routing_mock_get");
+    group.throughput(Throughput::Elements(1));
+
+    bench_get(
+        &mut group,
+        "primary_default",
+        ClusterClient::builder(vec!["redis://primary_default"]).retries(0),
+    );
+    bench_get(
+        &mut group,
+        "random_replica",
+        ClusterClient::builder(vec!["redis://random_replica"])
+            .retries(0)
+            .read_routing_strategy(RandomReplicaStrategy),
+    );
+    bench_get(
+        &mut group,
+        "round_robin_replica",
+        ClusterClient::builder(vec!["redis://round_robin_replica"])
+            .retries(0)
+            .read_routing_strategy(RoundRobinReplicaStrategy::new()),
+    );
+    bench_get(
+        &mut group,
+        "zonal_local_replica",
+        ClusterClient::builder(vec!["redis://zonal_local_replica"])
+            .retries(0)
+            .read_routing_strategy(ZonalReadRoutingStrategy::new("us-east-1b")),
+    );
+    bench_get(
+        &mut group,
+        "zonal_shared_local_replica",
+        ClusterClient::builder(vec!["redis://zonal_shared_local_replica"])
+            .retries(0)
+            .read_routing_strategy(ZonalReadRoutingStrategy::shared("us-east-1b")),
+    );
+
+    group.finish();
+}
+
+criterion_group!(cluster_read_routing_bench, bench_cluster_read_routing);
+criterion_main!(cluster_read_routing_bench);

--- a/redis/src/cluster_handling/read_routing/zonal_read_routing.rs
+++ b/redis/src/cluster_handling/read_routing/zonal_read_routing.rs
@@ -12,7 +12,7 @@ use crate::cluster_handling::NodeAddress;
 use crate::cluster_handling::slot_range_map::SlotRangeMap;
 
 struct ShardRoutingState {
-    local_replicas: HashSet<NodeAddress>,
+    local_replica_indices: Vec<usize>,
     counter: AtomicUsize,
 }
 
@@ -93,18 +93,19 @@ impl ReadRoutingStrategy for ZonalReadRoutingStrategy {
     fn on_topology_changed(&self, topology: ClusterTopology) {
         let mut slots = SlotRangeMap::new();
         for shard in topology.shards() {
-            let local_replicas = shard
+            let local_replica_indices = shard
                 .replicas()
                 .iter()
-                .filter(|replica| {
+                .enumerate()
+                .filter_map(|(idx, replica)| {
                     topology
                         .availability_zone_for_node(replica)
                         .is_some_and(|zone| zone == self.availability_zone.as_str())
+                        .then_some(idx)
                 })
-                .cloned()
                 .collect();
             let state = Arc::new(ShardRoutingState {
-                local_replicas,
+                local_replica_indices,
                 counter: AtomicUsize::new(0),
             });
             for &(start, end) in shard.slot_ranges() {
@@ -155,17 +156,12 @@ impl ReadRoutingStrategy for ZonalReadRoutingStrategy {
 
         if let Some(shard_state) = shard_state {
             let idx = shard_state.counter.fetch_add(1, Ordering::Relaxed);
-            let local_len = replicas
-                .iter()
-                .filter(|replica| shard_state.local_replicas.contains(*replica))
-                .count();
+            let local_len = shard_state.local_replica_indices.len();
             if local_len > 0 {
-                let target_idx = idx % local_len;
-                return replicas
-                    .iter()
-                    .filter(|replica| shard_state.local_replicas.contains(*replica))
-                    .nth(target_idx)
-                    .expect("local replica exists");
+                let target_idx = shard_state.local_replica_indices[idx % local_len];
+                if let Some(replica) = replicas.get(target_idx) {
+                    return replica;
+                }
             }
 
             return replicas


### PR DESCRIPTION
## Summary

Adds a no-server Criterion benchmark for cluster read-routing overhead and optimizes the zonal read-routing hot path. The zonal strategy now precomputes local replica indexes during topology refresh, avoiding per-read filtering through the replica list.

## Validation

- `cargo fmt --check`
- `cargo test -p redis --test test_cluster zonal --features cluster`
- `cargo test -p redis --test test_cluster_async zonal --features cluster-async,tokio-comp`
- `cargo clippy -p redis --all-targets --features cluster,cluster-async,tokio-comp -- -D warnings`
- `cargo bench -p redis --bench bench_cluster_read_routing --features cluster -- --noplot --sample-size 20 --warm-up-time 1 --measurement-time 2`

Latest benchmark medians from the mock cluster benchmark:

- `primary_default`: ~225.60 ns
- `random_replica`: ~233.68 ns
- `round_robin_replica`: ~244.62 ns
- `zonal_local_replica`: ~254.29 ns
- `zonal_shared_local_replica`: ~258.61 ns

## Notes

The existing server-backed cluster benchmark still requires a local Redis/Valkey server binary; this benchmark uses mock cluster support so it can run without `redis-server` on PATH.