### PR TITLE
fix(cluster): follow redirects for pipelines on sync client

### DIFF
--- a/redis/src/cluster_handling/sync_connection/mod.rs
+++ b/redis/src/cluster_handling/sync_connection/mod.rs
@@ -1338,6 +1338,11 @@ where
                     .get_connection_by_addr(&mut connections, &nc.addr)?
                     .recv_response()
                 {
+                    // The RESP parser reports server errors as
+                    // `Ok(Value::ServerError(_))` rather than `Err`.
+                    // A pipelined sub-command that gets a redirect/retryable error
+                    // needs to be processed in the Ok arm and retried
+                    Ok(item) if item.is_error_that_requires_action() => to_retry.push(*cmd_idx),
                     Ok(item) => results[*cmd_idx] = item,
                     Err(err) if err.is_cluster_error() => to_retry.push(*cmd_idx),
                     Err(err) => first_err = first_err.or(Some(err)),

--- a/redis/src/cluster_handling/sync_connection/pipeline.rs
+++ b/redis/src/cluster_handling/sync_connection/pipeline.rs
@@ -1,6 +1,7 @@
-use super::ClusterConnection;
+use super::{ClusterConnection, Connect};
 use crate::RedisError;
 use crate::cmd::{Cmd, cmd};
+use crate::connection::ConnectionLike;
 use crate::errors::ErrorKind;
 use crate::types::{FromRedisValue, HashSet, RedisResult, ToRedisArgs, Value, from_redis_value};
 
@@ -104,7 +105,10 @@ impl ClusterPipeline {
     ///     .cmd("GET").arg("key_2").query(&mut con).unwrap();
     /// ```
     #[inline]
-    pub fn query<T: FromRedisValue>(&self, con: &mut ClusterConnection) -> RedisResult<T> {
+    pub fn query<T: FromRedisValue>(
+        &self,
+        con: &mut ClusterConnection<impl ConnectionLike + Connect + Send>,
+    ) -> RedisResult<T> {
         for cmd in &self.commands {
             let cmd_name = std::str::from_utf8(cmd.arg_idx(0).unwrap_or(b""))
                 .unwrap_or("")
@@ -132,7 +136,10 @@ impl ClusterPipeline {
     /// this is useful for "SET" commands for which the response's content is not important.
     /// It avoids the need to define generic bounds for ().
     #[inline]
-    pub fn exec(&self, con: &mut ClusterConnection) -> RedisResult<()> {
+    pub fn exec(
+        &self,
+        con: &mut ClusterConnection<impl ConnectionLike + Connect + Send>,
+    ) -> RedisResult<()> {
         self.query::<()>(con)
     }
 }

--- a/redis/src/errors/server_error.rs
+++ b/redis/src/errors/server_error.rs
@@ -120,7 +120,7 @@ impl ServerError {
         }
     }
 
-    #[cfg(feature = "cluster-async")]
+    #[cfg(any(feature = "cluster", feature = "cluster-async"))]
     pub(crate) fn requires_action(&self) -> bool {
         !matches!(
             self.kind()

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -558,7 +558,7 @@ impl Value {
         }
     }
 
-    #[cfg(feature = "cluster-async")]
+    #[cfg(any(feature = "cluster", feature = "cluster-async"))]
     pub(crate) fn is_error_that_requires_action(&self) -> bool {
         matches!(self, Self::ServerError(error) if error.requires_action())
     }

--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -92,7 +92,9 @@ impl cluster::Connect for MockConnection {
     }
 
     fn recv_response(&mut self) -> RedisResult<Value> {
-        Ok(Value::Nil)
+        // Drive responses from the handler so cluster-pipeline tests can inject inline per-command replies (e.g. `MOVED`).
+        // Invoked only by the cluster pipeline receive path. Only supports differentiating response based on port
+        (self.handler)(&[], self.port).expect_err("Handler did not specify a response")
     }
 }
 

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -494,6 +494,50 @@ mod cluster {
     }
 
     #[test]
+    fn test_cluster_pipeline_moved_redirect() {
+        // A `MOVED` returned for a pipelined sub-command is delivered
+        // inline as `Ok(Value::ServerError(Moved))`, and must be followed per command
+        //
+        // Both commands target the same slot, so they are sent as one sub-pipeline to the initial owner,
+        // which reports the slot has moved.
+        let name = "test_cluster_pipeline_moved_redirect";
+
+        let MockEnv {
+            mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::new(name, move |cmd: &[u8], port| {
+            respond_startup(name, cmd)?;
+
+            if port == 6379 {
+                // Initial slot owner reports the slot moved. For the pipelined sub-commands
+                // this reply is returned via `recv_response` (cmd == &[]).
+                return Err(parse_redis_value(
+                    format!("-MOVED 123 {name}:6380\r\n").as_bytes(),
+                ));
+            }
+
+            // Redirect target serves the individually retried commands.
+            assert_eq!(port, 6380);
+            if contains_slice(cmd, b"GET") {
+                Err(Ok(redis_value!("val1")))
+            } else {
+                Err(Ok(redis_value!(simple: "OK")))
+            }
+        });
+
+        let value = cluster_pipe()
+            .cmd("SET")
+            .arg("key1")
+            .arg("val1")
+            .cmd("GET")
+            .arg("key1")
+            .query::<Vec<String>>(&mut connection);
+
+        assert_eq!(value, Ok(vec!["OK".to_string(), "val1".to_string()]));
+    }
+
+    #[test]
     fn test_cluster_ask_redirect() {
         let name = "test_cluster_ask_redirect";
         let completed = Arc::new(AtomicI32::new(0));


### PR DESCRIPTION
The synchronous cluster client does not follow redirects for commands sent in a pipeline. During cluster resharding a pipelined sub-command that receives `MOVED`, `ASK`, `TRYAGAIN` or `CLUSTERDOWN` is returned to the caller unretried, as a `Pipeline failures` list of errors. We hit this in production against Valkey on AWS Elasticache while the cluster was resharding.

The issue started in commit [`f9ab3d8`](https://github.com/redis-rs/redis-rs/commit/f9ab3d8345f9abc40aba7cc57699eb46def7fc64), where the parser stopped converting server errors into a `RedisError` and began returning them inline as `Ok(ServerError)`. The sync cluster pipeline code in `recv_all_commands` reads responses through `recv_response` and was not updated to handle this refactor. Its `is_cluster_error` retry arm only matches an `Err`, so the redirect is now unhandled and is stored as a result instead of being retried.

The current change wires these retryable errors to the existing per-command retry path using the `is_error_that_requires_action` method. This is the same logic the async cluster pipeline code already uses. Otherwise, all error handling remains the same. The cfg gating for `is_error_that_requires_action` and `requires_action` was previously only for the `cluster-async` feature, so this change adds `cluster` to the cfg macro.