### PR TITLE
Add UniformRandom read routing strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.114",
 ]
 
@@ -569,14 +569,14 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.39"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -665,9 +665,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cmake"
-version = "0.1.54"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -919,9 +919,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.2"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -2673,6 +2673,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"

--- a/redis/benches/bench_cluster.rs
+++ b/redis/benches/bench_cluster.rs
@@ -3,7 +3,7 @@ use std::hint::black_box;
 
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use redis::cluster::cluster_pipe;
-use redis::cluster_read_routing::RandomReplicaStrategy;
+use redis::cluster_read_routing::{RandomReplicaStrategy, UniformRandom};
 use redis_test::cluster::RedisClusterConfiguration;
 
 use support::*;
@@ -13,10 +13,14 @@ mod support;
 
 const PIPELINE_QUERIES: usize = 100;
 
-fn bench_set_get_and_del(c: &mut Criterion, con: &mut redis::cluster::ClusterConnection) {
+fn bench_set_get_and_del(
+    c: &mut Criterion,
+    con: &mut redis::cluster::ClusterConnection,
+    strategy_name: &str,
+) {
     let key = "test_key";
 
-    let mut group = c.benchmark_group("cluster_basic");
+    let mut group = c.benchmark_group(format!("cluster_basic_{strategy_name}"));
 
     group.bench_function("set", |b| {
         b.iter(|| {
@@ -43,8 +47,12 @@ fn bench_set_get_and_del(c: &mut Criterion, con: &mut redis::cluster::ClusterCon
     group.finish();
 }
 
-fn bench_pipeline(c: &mut Criterion, con: &mut redis::cluster::ClusterConnection) {
-    let mut group = c.benchmark_group("cluster_pipeline");
+fn bench_pipeline(
+    c: &mut Criterion,
+    con: &mut redis::cluster::ClusterConnection,
+    strategy_name: &str,
+) {
+    let mut group = c.benchmark_group(format!("cluster_pipeline_{strategy_name}"));
     group.throughput(Throughput::Elements(PIPELINE_QUERIES as u64));
 
     let mut queries = Vec::new();
@@ -85,11 +93,10 @@ fn bench_cluster_setup(c: &mut Criterion) {
     cluster.wait_for_cluster_up();
 
     let mut con = cluster.connection();
-    bench_set_get_and_del(c, &mut con);
-    bench_pipeline(c, &mut con);
+    bench_set_get_and_del(c, &mut con, "primary");
+    bench_pipeline(c, &mut con, "primary");
 }
 
-#[allow(dead_code)]
 fn bench_cluster_read_from_replicas_setup(c: &mut Criterion) {
     let cluster = TestClusterContext::new_with_config_and_builder(
         RedisClusterConfiguration::single_replica_config(),
@@ -98,13 +105,26 @@ fn bench_cluster_read_from_replicas_setup(c: &mut Criterion) {
     cluster.wait_for_cluster_up();
 
     let mut con = cluster.connection();
-    bench_set_get_and_del(c, &mut con);
-    bench_pipeline(c, &mut con);
+    bench_set_get_and_del(c, &mut con, "random_replica");
+    bench_pipeline(c, &mut con, "random_replica");
+}
+
+fn bench_cluster_uniform_random_setup(c: &mut Criterion) {
+    let cluster = TestClusterContext::new_with_config_and_builder(
+        RedisClusterConfiguration::single_replica_config(),
+        |builder| builder.read_routing_strategy(UniformRandom::new()),
+    );
+    cluster.wait_for_cluster_up();
+
+    let mut con = cluster.connection();
+    bench_set_get_and_del(c, &mut con, "uniform_random");
+    bench_pipeline(c, &mut con, "uniform_random");
 }
 
 criterion_group!(
     cluster_bench,
     bench_cluster_setup,
-    // bench_cluster_read_from_replicas_setup
+    bench_cluster_read_from_replicas_setup,
+    bench_cluster_uniform_random_setup,
 );
 criterion_main!(cluster_bench);

--- a/redis/benches/bench_cluster_read_routing.rs
+++ b/redis/benches/bench_cluster_read_routing.rs
@@ -136,6 +136,29 @@ fn mock_env(name: &'static str, builder: redis::cluster::ClusterClientBuilder) -
     })
 }
 
+fn mock_multi_slot_env(
+    name: &'static str,
+    builder: redis::cluster::ClusterClientBuilder,
+) -> MockEnv {
+    let slots_config = slots_config();
+    MockEnv::with_client_builder(builder, name, move |packed_command: &[u8], _port| {
+        if is_connection_check(packed_command) {
+            return Err(Ok(Value::SimpleString("OK".into())));
+        }
+        if contains_slice(packed_command, b"CLUSTER") && contains_slice(packed_command, b"SLOTS") {
+            return respond_startup_with_replica_using_config(
+                name,
+                packed_command,
+                Some(slots_config.clone()),
+            );
+        }
+        if contains_slice(packed_command, b"MGET") {
+            return Err(Ok(Value::Array(vec![Value::BulkString(b"123".to_vec())])));
+        }
+        Ok(())
+    })
+}
+
 fn bench_get(
     group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
     name: &'static str,
@@ -204,6 +227,27 @@ fn bench_cluster_read_routing(c: &mut Criterion) {
             .read_routing_strategy(ZonalReadRoutingStrategy::shared("us-east-1b")),
     );
 
+    group.finish();
+
+    let mut group = c.benchmark_group("cluster_read_routing_mock_multi_slot");
+    group.throughput(Throughput::Elements(2));
+    let mut env = mock_multi_slot_env(
+        "round_robin_multi_slot",
+        ClusterClient::builder(vec!["redis://round_robin_multi_slot"])
+            .retries(0)
+            .read_routing_strategy(RoundRobinReplicaStrategy::new()),
+    );
+    let mut command = cmd("MGET");
+    command.arg("test").arg("{foo}test");
+    let values = command.query::<Vec<i32>>(&mut env.connection).unwrap();
+    assert_eq!(values, vec![123, 123]);
+
+    group.bench_function("round_robin_replica", |b| {
+        b.iter(|| {
+            let values = command.query::<Vec<i32>>(&mut env.connection).unwrap();
+            black_box(values)
+        });
+    });
     group.finish();
 }
 

--- a/redis/benches/bench_cluster_read_routing.rs
+++ b/redis/benches/bench_cluster_read_routing.rs
@@ -5,7 +5,7 @@ use std::hint::black_box;
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use redis::cluster::ClusterClient;
 use redis::cluster_read_routing::{
-    RandomReplicaStrategy, RoundRobinReplicaStrategy, ZonalReadRoutingStrategy,
+    RandomReplicaStrategy, RoundRobinReplicaStrategy, UniformRandom, ZonalReadRoutingStrategy,
 };
 use redis::{Value, cmd};
 
@@ -142,6 +142,12 @@ fn bench_get(
     builder: redis::cluster::ClusterClientBuilder,
 ) {
     let mut env = mock_env(name, builder);
+    let value: Option<i32> = cmd("GET")
+        .arg(black_box("{bench}key"))
+        .query(&mut env.connection)
+        .unwrap();
+    assert_eq!(value, Some(123));
+
     group.bench_function(name, |b| {
         b.iter(|| {
             let value: Option<i32> = cmd("GET")
@@ -175,6 +181,13 @@ fn bench_cluster_read_routing(c: &mut Criterion) {
         ClusterClient::builder(vec!["redis://round_robin_replica"])
             .retries(0)
             .read_routing_strategy(RoundRobinReplicaStrategy::new()),
+    );
+    bench_get(
+        &mut group,
+        "uniform_random",
+        ClusterClient::builder(vec!["redis://uniform_random"])
+            .retries(0)
+            .read_routing_strategy(UniformRandom::new()),
     );
     bench_get(
         &mut group,

--- a/redis/src/cluster_handling/async_connection/mod.rs
+++ b/redis/src/cluster_handling/async_connection/mod.rs
@@ -97,7 +97,10 @@ use std::{
     io,
     ops::Deref,
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
     task::{self, Poll},
     time::Duration,
 };
@@ -121,7 +124,8 @@ use crate::{
             ReadRoutingStrategy,
         },
         routing::{
-            MultipleNodeRoutingInfo, Redirect, ResponsePolicy, RoutingInfo, SingleNodeRoutingInfo,
+            MultipleNodeRoutingInfo, Redirect, ResponsePolicy, Route, RoutingInfo,
+            SingleNodeRoutingInfo, SlotAddr,
         },
         shard_cmd, slot_cmd,
         slot_map::{SlotMap, SlotRange},
@@ -447,11 +451,13 @@ type ConnectionMap<C> = HashMap<NodeAddress, C>;
 /// as common parameters for connecting to nodes and executing commands.
 struct InnerCore<C> {
     conn_lock: RwLock<(ConnectionMap<C>, SlotMap)>,
+    connection_generation: AtomicU64,
     cluster_params: ClusterParams,
     pending_requests_tx: mpsc::UnboundedSender<PendingRequest<C>>,
     initial_nodes: Vec<ConnectionInfo>,
     subscription_tracker: Option<Mutex<SubscriptionTracker>>,
     routing_strategy: Option<Box<dyn ReadRoutingStrategy>>,
+    read_fallback_enabled: bool,
     az_discovery: Arc<NodeAvailabilityZoneDiscoveryState>,
 }
 
@@ -491,54 +497,88 @@ where
             );
         }
         let (receivers, requests): (Vec<_>, Vec<_>) = {
-            let to_request = |(addr, cmd): (&NodeAddress, Arc<Cmd>)| {
-                read_guard.0.get(addr).cloned().map(|conn| {
+            let to_request =
+                |addr: NodeAddress, cmd: Arc<Cmd>, routing: InternalSingleNodeRouting<C>| {
                     let (sender, receiver) = oneshot::channel();
-                    let addr = addr.clone();
                     (
-                        (addr.clone(), receiver),
+                        (addr, receiver),
                         PendingRequest {
                             retry: 0,
                             sender: request::ResultExpectation::External(sender),
                             cmd: CmdArg::Cmd {
                                 cmd,
-                                routing: InternalSingleNodeRouting::Connection {
-                                    identifier: addr,
-                                    conn,
-                                }
-                                .into(),
+                                routing: routing.into(),
                             },
+                            excluded_read_nodes: Vec::new(),
                         },
                     )
-                })
-            };
+                };
             let slot_map = &read_guard.1;
 
-            // TODO - these filter_map calls mean that we ignore nodes that are missing. Should we report an error in such cases?
-            // since some of the operators drop other requests, mapping to errors here might mean that no request is sent.
             match routing {
                 MultipleNodeRoutingInfo::AllNodes => slot_map
                     .addresses_for_all_nodes()
                     .into_iter()
-                    .filter_map(|addr| to_request((addr, cmd.clone())))
+                    .filter_map(|addr| {
+                        let addr = addr.clone();
+                        let request_routing = if let Some(conn) = read_guard.0.get(&addr).cloned() {
+                            InternalSingleNodeRouting::Connection {
+                                identifier: addr.clone(),
+                                conn,
+                            }
+                        } else if self.read_fallback_enabled {
+                            InternalSingleNodeRouting::ByAddressTransient(addr.clone())
+                        } else {
+                            return None;
+                        };
+                        Some(to_request(addr, cmd.clone(), request_routing))
+                    })
                     .unzip(),
                 MultipleNodeRoutingInfo::AllMasters => slot_map
                     .addresses_for_all_primaries()
                     .into_iter()
-                    .filter_map(|addr| to_request((addr, cmd.clone())))
+                    .filter_map(|addr| {
+                        read_guard.0.get(addr).cloned().map(|conn| {
+                            let addr = addr.clone();
+                            to_request(
+                                addr.clone(),
+                                cmd.clone(),
+                                InternalSingleNodeRouting::Connection {
+                                    identifier: addr,
+                                    conn,
+                                },
+                            )
+                        })
+                    })
                     .unzip(),
                 MultipleNodeRoutingInfo::MultiSlot((routes, _)) => slot_map
                     .addresses_for_multi_slot(routes, self.routing_strategy.as_deref())
                     .enumerate()
                     .filter_map(|(index, addr_opt)| {
                         addr_opt.and_then(|addr| {
-                            let (_, indices) = routes.get(index).unwrap();
+                            let (route, indices) = routes.get(index).unwrap();
                             let cmd =
                                 Arc::new(crate::cluster_routing::command_for_multi_slot_indices(
                                     cmd.as_ref(),
                                     indices.iter(),
                                 ));
-                            to_request((addr, cmd))
+                            let request_routing = if self.read_fallback_enabled
+                                && matches!(
+                                    route.slot_addr(),
+                                    SlotAddr::ReplicaOptional | SlotAddr::ReplicaRequired
+                                ) {
+                                InternalSingleNodeRouting::SpecificNodeWithPreferred {
+                                    route: *route,
+                                    preferred: addr.clone(),
+                                }
+                            } else {
+                                let conn = read_guard.0.get(addr)?.clone();
+                                InternalSingleNodeRouting::Connection {
+                                    identifier: addr.clone(),
+                                    conn,
+                                }
+                            };
+                            Some(to_request(addr.clone(), cmd, request_routing))
                         })
                     })
                     .unzip(),
@@ -699,6 +739,7 @@ where
         &self,
         cmd: Arc<Cmd>,
         routing: InternalRoutingInfo<C>,
+        excluded_read_nodes: Vec<NodeAddress>,
     ) -> OperationResult {
         let route = match routing {
             InternalRoutingInfo::SingleNode(single_node_routing) => single_node_routing,
@@ -709,7 +750,7 @@ where
             }
         };
 
-        match self.get_connection(route).await {
+        match self.get_connection(route, &excluded_read_nodes).await {
             Ok((addr, mut conn)) => (
                 addr.into(),
                 conn.req_packed_command(&cmd)
@@ -738,8 +779,9 @@ where
         offset: usize,
         count: usize,
         route: InternalSingleNodeRouting<C>,
+        excluded_read_nodes: Vec<NodeAddress>,
     ) -> OperationResult {
-        match self.get_connection(route).await {
+        match self.get_connection(route, &excluded_read_nodes).await {
             Ok((addr, mut conn)) => (
                 OperationTarget::Node { address: addr },
                 conn.req_packed_commands(&pipeline, offset, count)
@@ -781,16 +823,23 @@ where
         }
     }
 
-    async fn try_request(self, cmd: CmdArg<C>) -> OperationResult {
+    async fn try_request(
+        self,
+        cmd: CmdArg<C>,
+        excluded_read_nodes: Vec<NodeAddress>,
+    ) -> OperationResult {
         match cmd {
-            CmdArg::Cmd { cmd, routing } => self.try_cmd_request(cmd, routing).await,
+            CmdArg::Cmd { cmd, routing } => {
+                self.try_cmd_request(cmd, routing, excluded_read_nodes)
+                    .await
+            }
             CmdArg::Pipeline {
                 pipeline,
                 offset,
                 count,
                 route,
             } => {
-                self.try_pipeline_request(pipeline, offset, count, route)
+                self.try_pipeline_request(pipeline, offset, count, route, excluded_read_nodes)
                     .await
             }
         }
@@ -799,7 +848,31 @@ where
     async fn get_connection(
         &self,
         route: InternalSingleNodeRouting<C>,
+        excluded_read_nodes: &[NodeAddress],
     ) -> RedisResult<(NodeAddress, C)> {
+        if self.read_fallback_enabled {
+            match &route {
+                InternalSingleNodeRouting::SpecificNode(route)
+                    if (!excluded_read_nodes.is_empty()
+                        || route.slot_addr() == SlotAddr::ReplicaRequired)
+                        && matches!(
+                            route.slot_addr(),
+                            SlotAddr::ReplicaOptional | SlotAddr::ReplicaRequired
+                        ) =>
+                {
+                    return self
+                        .get_connection_for_read_route(*route, excluded_read_nodes, None)
+                        .await;
+                }
+                InternalSingleNodeRouting::SpecificNodeWithPreferred { route, preferred } => {
+                    return self
+                        .get_connection_for_read_route(*route, excluded_read_nodes, Some(preferred))
+                        .await;
+                }
+                _ => {}
+            }
+        }
+
         let read_guard = self.conn_lock.read().await;
 
         let conn = match route {
@@ -808,18 +881,28 @@ where
                 .1
                 .slot_addr_for_route(&route, self.routing_strategy.as_deref())
                 .cloned(),
+            InternalSingleNodeRouting::SpecificNodeWithPreferred { preferred, .. } => {
+                Some(preferred)
+            }
             InternalSingleNodeRouting::Connection { identifier, conn } => {
                 return Ok((identifier, conn));
             }
-            InternalSingleNodeRouting::Redirect { redirect, .. } => {
+            InternalSingleNodeRouting::Redirect {
+                redirect,
+                previous_routing,
+            } => {
+                let retain_connection = !previous_routing.is_transient();
                 drop(read_guard);
                 // redirected requests shouldn't use a random connection, so they have a separate codepath.
-                return self.get_redirected_connection(redirect).await;
+                return self
+                    .get_redirected_connection(redirect, retain_connection)
+                    .await;
             }
             InternalSingleNodeRouting::ByAddress(address) => {
                 if let Some(conn) = read_guard.0.get(&address).cloned() {
                     return Ok((address, conn));
-                } else {
+                }
+                if !self.read_fallback_enabled {
                     return Err((
                         ErrorKind::Client,
                         "Requested connection not found",
@@ -827,6 +910,14 @@ where
                     )
                         .into());
                 }
+                drop(read_guard);
+                let conn = self.connect_check_and_add(&address).await?;
+                return Ok((address, conn));
+            }
+            InternalSingleNodeRouting::ByAddressTransient(address) => {
+                drop(read_guard);
+                let conn = connect_and_check::<C>(&address, &self.cluster_params).await?;
+                return Ok((address, conn));
             }
         }
         .map(|addr| {
@@ -863,18 +954,85 @@ where
         Ok((addr, conn))
     }
 
-    async fn get_redirected_connection(&self, redirect: Redirect) -> RedisResult<(NodeAddress, C)> {
+    async fn get_connection_for_read_route(
+        &self,
+        route: Route,
+        excluded_read_nodes: &[NodeAddress],
+        preferred: Option<&NodeAddress>,
+    ) -> RedisResult<(NodeAddress, C)> {
+        let mut excluded_nodes = excluded_read_nodes.to_vec();
+        let mut last_error = None;
+
+        loop {
+            let read_guard = self.conn_lock.read().await;
+            let addr = preferred
+                .filter(|address| !excluded_nodes.contains(address))
+                .cloned()
+                .or_else(|| {
+                    read_guard
+                        .1
+                        .slot_addr_for_route_excluding(
+                            &route,
+                            self.routing_strategy.as_deref(),
+                            &excluded_nodes,
+                        )
+                        .cloned()
+                });
+
+            let Some(addr) = addr else {
+                if let Some(err) = last_error {
+                    return Err(err);
+                }
+                if excluded_nodes.is_empty() {
+                    if let Some((addr, conn)) = get_random_connection(&read_guard.0) {
+                        return Ok((addr, conn));
+                    }
+                }
+                return Err((
+                    ErrorKind::ClusterConnectionNotFound,
+                    "No eligible read connection found",
+                )
+                    .into());
+            };
+
+            if let Some(conn) = read_guard.0.get(&addr).cloned() {
+                return Ok((addr, conn));
+            }
+
+            drop(read_guard);
+
+            match self.connect_check_and_add(&addr).await {
+                Ok(conn) => return Ok((addr, conn)),
+                Err(err) => {
+                    if excluded_nodes.contains(&addr) {
+                        return Err(err);
+                    }
+                    excluded_nodes.push(addr);
+                    last_error = Some(err);
+                }
+            }
+        }
+    }
+
+    async fn get_redirected_connection(
+        &self,
+        redirect: Redirect,
+        retain_connection: bool,
+    ) -> RedisResult<(NodeAddress, C)> {
         let asking = matches!(redirect, Redirect::Ask(_));
         let addr = match redirect {
             Redirect::Moved(addr) => addr,
             Redirect::Ask(addr) => addr,
         };
         let read_guard = self.conn_lock.read().await;
-        let conn = read_guard.0.get(&addr).cloned();
+        let conn = retain_connection
+            .then(|| read_guard.0.get(&addr).cloned())
+            .flatten();
         drop(read_guard);
         let mut conn = match conn {
             Some(conn) => conn,
-            None => self.connect_check_and_add(&addr).await?,
+            None if retain_connection => self.connect_check_and_add(&addr).await?,
+            None => connect_and_check::<C>(&addr, &self.cluster_params).await?,
         };
         if asking {
             let mut asking_cmd = crate::cmd::cmd("ASKING");
@@ -889,13 +1047,16 @@ where
     }
 
     async fn connect_check_and_add(&self, addr: &NodeAddress) -> RedisResult<C> {
+        let generation = self.connection_generation.load(Ordering::Acquire);
         match connect_and_check::<C>(addr, &self.cluster_params).await {
             Ok(conn) => {
-                self.conn_lock
-                    .write()
-                    .await
-                    .0
-                    .insert(addr.clone(), conn.clone());
+                let mut write_guard = self.conn_lock.write().await;
+                if generation == self.connection_generation.load(Ordering::Acquire) {
+                    write_guard.0.insert(addr.clone(), conn.clone());
+                    if let Some(strategy) = &self.routing_strategy {
+                        strategy.on_connection_added(addr);
+                    }
+                }
                 Ok(conn)
             }
             Err(err) => Err(err),
@@ -943,12 +1104,14 @@ where
             let nodes = strategy
                 .eager_connection_nodes(&topology)
                 .unwrap_or_else(|| slots.values().flatten().cloned().collect());
-            self.refresh_connections_locked(connections, nodes).await;
+            self.refresh_connections_locked(connections, nodes, true)
+                .await;
             return Ok(());
         }
 
         let nodes = slots.values().flatten().cloned().collect::<HashSet<_>>();
-        self.refresh_connections_locked(connections, nodes).await;
+        self.refresh_connections_locked(connections, nodes, true)
+            .await;
 
         Ok(())
     }
@@ -1169,7 +1332,11 @@ where
         &self,
         connections: &mut ConnectionMap<C>,
         nodes: HashSet<NodeAddress>,
+        prune_unrequested: bool,
     ) {
+        if prune_unrequested {
+            connections.retain(|address, _| nodes.contains(address));
+        }
         let nodes_len = nodes.len();
 
         let addresses_and_connections_iter = nodes
@@ -1185,13 +1352,23 @@ where
 
         stream::iter(addresses_and_connections_iter)
             .buffer_unordered(nodes_len.max(8))
-            .fold(connections, |connections, (addr, result)| async move {
-                if let Ok(conn) = result {
-                    connections.insert(addr, conn);
-                }
-                connections
-            })
+            .fold(
+                &mut *connections,
+                |connections, (addr, result)| async move {
+                    if let Ok(conn) = result {
+                        connections.insert(addr, conn);
+                    }
+                    connections
+                },
+            )
             .await;
+        if let Some(strategy) = &self.routing_strategy {
+            let connected_nodes = connections.keys().cloned().collect();
+            strategy.on_connections_changed(&connected_nodes);
+        }
+        if prune_unrequested {
+            self.connection_generation.fetch_add(1, Ordering::Release);
+        }
     }
 
     fn resubscribe(&self) {
@@ -1216,6 +1393,7 @@ where
                     cmd: Arc::new(cmd),
                     routing,
                 },
+                excluded_read_nodes: Vec::new(),
             }
         });
         for request in requests {
@@ -1309,15 +1487,20 @@ where
             .read_routing_factory
             .as_ref()
             .map(|f| f.create_strategy());
+        let read_fallback_enabled = routing_strategy
+            .as_deref()
+            .is_some_and(ReadRoutingStrategy::supports_read_fallback);
 
         let (pending_requests_tx, pending_requests_rx) = mpsc::unbounded_channel();
         let inner = Arc::new(InnerCore {
             conn_lock: RwLock::new((Default::default(), SlotMap::new())),
+            connection_generation: AtomicU64::new(0),
             cluster_params,
             pending_requests_tx,
             initial_nodes: initial_nodes.to_vec(),
             subscription_tracker,
             routing_strategy,
+            read_fallback_enabled,
             az_discovery: Arc::new(NodeAvailabilityZoneDiscoveryState::default()),
         });
         let core = Core(inner);
@@ -1407,7 +1590,7 @@ where
             let mut write_guard = inner.conn_lock.write().await;
 
             inner
-                .refresh_connections_locked(&mut write_guard.0, addrs)
+                .refresh_connections_locked(&mut write_guard.0, addrs, false)
                 .await;
         }
     }
@@ -1463,7 +1646,10 @@ where
                 let _ = self.inner.pending_requests_tx.send(request);
             }
             Some(Retry::Immediately { request }) => {
-                let future = self.inner.clone().try_request(request.cmd.clone());
+                let future = self
+                    .inner
+                    .clone()
+                    .try_request(request.cmd.clone(), request.excluded_read_nodes.clone());
                 self.in_flight_requests.push(Box::pin(Request {
                     retry_params: self.inner.cluster_params.retry_params.clone(),
                     request: Some(request),
@@ -1506,7 +1692,11 @@ where
                 continue;
             }
 
-            let future = self.inner.clone().try_request(request.cmd.clone()).boxed();
+            let future = self
+                .inner
+                .clone()
+                .try_request(request.cmd.clone(), request.excluded_read_nodes.clone())
+                .boxed();
             self.in_flight_requests.push(Box::pin(Request {
                 retry_params: self.inner.cluster_params.retry_params.clone(),
                 request: Some(request),
@@ -1633,6 +1823,7 @@ where
             retry: 0,
             sender: request::ResultExpectation::External(sender),
             cmd,
+            excluded_read_nodes: Vec::new(),
         });
         Ok(())
     }

--- a/redis/src/cluster_handling/async_connection/request.rs
+++ b/redis/src/cluster_handling/async_connection/request.rs
@@ -9,8 +9,11 @@ use std::{
 
 use crate::errors::RetryMethod;
 use crate::{
-    Cmd, RedisResult, cluster_async::OperationTarget, cluster_handling::NodeAddress,
-    cluster_handling::client::RetryParams, cluster_routing::Redirect,
+    Cmd, ErrorKind, RedisResult,
+    cluster_async::OperationTarget,
+    cluster_handling::NodeAddress,
+    cluster_handling::client::RetryParams,
+    cluster_routing::{Redirect, SlotAddr},
 };
 
 use futures_util::{future::BoxFuture, ready};
@@ -51,6 +54,43 @@ pub(super) enum Retry<C> {
 }
 
 impl<C> CmdArg<C> {
+    fn route_uses_read_fallback(route: &InternalSingleNodeRouting<C>) -> bool {
+        match route {
+            InternalSingleNodeRouting::SpecificNode(route) => matches!(
+                route.slot_addr(),
+                SlotAddr::ReplicaOptional | SlotAddr::ReplicaRequired
+            ),
+            InternalSingleNodeRouting::SpecificNodeWithPreferred { route, .. } => matches!(
+                route.slot_addr(),
+                SlotAddr::ReplicaOptional | SlotAddr::ReplicaRequired
+            ),
+            InternalSingleNodeRouting::Redirect {
+                previous_routing, ..
+            } => Self::route_uses_read_fallback(previous_routing),
+            _ => false,
+        }
+    }
+
+    fn uses_read_fallback(&self) -> bool {
+        match self {
+            CmdArg::Cmd { routing, .. } => match routing {
+                InternalRoutingInfo::SingleNode(route) => Self::route_uses_read_fallback(route),
+                InternalRoutingInfo::MultiNode(_) => false,
+            },
+            CmdArg::Pipeline { route, .. } => Self::route_uses_read_fallback(route),
+        }
+    }
+
+    fn is_transient(&self) -> bool {
+        match self {
+            CmdArg::Cmd { routing, .. } => match routing {
+                InternalRoutingInfo::SingleNode(route) => route.is_transient(),
+                InternalRoutingInfo::MultiNode(_) => false,
+            },
+            CmdArg::Pipeline { route, .. } => route.is_transient(),
+        }
+    }
+
     fn set_redirect(&mut self, redirect: Option<Redirect>) {
         if let Some(redirect) = redirect {
             match self {
@@ -80,19 +120,32 @@ impl<C> CmdArg<C> {
 
     fn reset_routing(&mut self) {
         let fix_route = |route: &mut InternalSingleNodeRouting<C>| {
-            match route {
-                InternalSingleNodeRouting::Redirect {
-                    previous_routing, ..
-                } => {
-                    let previous_routing = std::mem::take(previous_routing.as_mut());
-                    *route = previous_routing;
+            let mut current = std::mem::take(route);
+            loop {
+                match current {
+                    InternalSingleNodeRouting::Redirect {
+                        previous_routing, ..
+                    } => {
+                        current = *previous_routing;
+                    }
+                    InternalSingleNodeRouting::SpecificNodeWithPreferred {
+                        route: slot_route,
+                        ..
+                    } => {
+                        *route = InternalSingleNodeRouting::SpecificNode(slot_route);
+                        break;
+                    }
+                    // If a specific connection is specified, then reconnecting without resetting
+                    // the routing will mean that the request is still routed to the old connection.
+                    InternalSingleNodeRouting::Connection { identifier, .. } => {
+                        *route = InternalSingleNodeRouting::ByAddress(identifier);
+                        break;
+                    }
+                    current_route => {
+                        *route = current_route;
+                        break;
+                    }
                 }
-                // If a specific connection is specified, then reconnecting without resetting the routing
-                // will mean that the request is still routed to the old connection.
-                InternalSingleNodeRouting::Connection { identifier, .. } => {
-                    *route = InternalSingleNodeRouting::ByAddress(std::mem::take(identifier));
-                }
-                _ => {}
             }
         };
         match self {
@@ -150,6 +203,15 @@ pub(super) struct PendingRequest<C> {
     pub(super) retry: u32,
     pub(super) sender: ResultExpectation,
     pub(super) cmd: CmdArg<C>,
+    pub(super) excluded_read_nodes: Vec<NodeAddress>,
+}
+
+impl<C> PendingRequest<C> {
+    fn mark_read_node_failed(&mut self, address: &NodeAddress) {
+        if self.cmd.uses_read_fallback() && !self.excluded_read_nodes.contains(address) {
+            self.excluded_read_nodes.push(address.clone());
+        }
+    }
 }
 
 pin_project! {
@@ -215,8 +277,17 @@ pub(crate) fn choose_response<C>(
             (retry, PollFlushAction::ReconnectFromInitialConnections)
         }
 
+        (OperationTarget::Node { .. }, RetryMethod::Reconnect) if request.cmd.is_transient() => (
+            retry_or_send!(|mut request: PendingRequest<C>| {
+                request.cmd.reset_routing();
+                Retry::Immediately { request }
+            }),
+            PollFlushAction::None,
+        ),
+
         (OperationTarget::Node { address }, RetryMethod::Reconnect) => (
             retry_or_send!(|mut request: PendingRequest<C>| {
+                request.mark_read_node_failed(&address);
                 request.cmd.reset_routing();
                 Retry::MoveToPending { request }
             }),
@@ -276,6 +347,19 @@ pub(crate) fn choose_response<C>(
         (_, RetryMethod::NoRetry) => {
             request.sender.send(Err(err));
             (None, PollFlushAction::None)
+        }
+
+        (OperationTarget::Node { address }, RetryMethod::RetryImmediately)
+            if err.kind() == ErrorKind::Io =>
+        {
+            (
+                retry_or_send!(|mut request: PendingRequest<C>| {
+                    request.mark_read_node_failed(&address);
+                    request.cmd.reset_routing();
+                    Retry::Immediately { request }
+                }),
+                PollFlushAction::None,
+            )
         }
 
         (_, RetryMethod::RetryImmediately) => (
@@ -364,6 +448,7 @@ mod tests {
                     cmd: Arc::new(crate::cmd("foo")),
                     routing: routing::InternalSingleNodeRouting::Random.into(),
                 },
+                excluded_read_nodes: Vec::new(),
             },
             receiver,
         )
@@ -380,6 +465,44 @@ mod tests {
             .unwrap()
             .extract_error()
             .unwrap_err()
+    }
+
+    #[test]
+    fn reset_routing_discards_a_stale_multi_slot_preference_after_redirect() {
+        let route = crate::cluster_routing::Route::with_key(
+            "key",
+            crate::cluster_routing::SlotAddr::ReplicaOptional,
+        );
+        let mut cmd = CmdArg::<usize>::Cmd {
+            cmd: Arc::new(crate::cmd("GET")),
+            routing: InternalSingleNodeRouting::Redirect {
+                redirect: Redirect::Moved(ADDRESS),
+                previous_routing: Box::new(InternalSingleNodeRouting::Redirect {
+                    redirect: Redirect::Ask(NodeAddress::from_parts(
+                        arcstr::literal!("intermediate"),
+                        6380,
+                    )),
+                    previous_routing: Box::new(
+                        InternalSingleNodeRouting::SpecificNodeWithPreferred {
+                            route,
+                            preferred: NodeAddress::from_parts(arcstr::literal!("stale"), 6379),
+                        },
+                    ),
+                }),
+            }
+            .into(),
+        };
+
+        cmd.reset_routing();
+
+        match cmd {
+            CmdArg::Cmd {
+                routing:
+                    InternalRoutingInfo::SingleNode(InternalSingleNodeRouting::SpecificNode(actual)),
+                ..
+            } => assert_eq!(actual, route),
+            _ => panic!("expected slot-based routing after reset"),
+        }
     }
 
     #[test]

--- a/redis/src/cluster_handling/async_connection/routing.rs
+++ b/redis/src/cluster_handling/async_connection/routing.rs
@@ -43,7 +43,13 @@ pub(super) enum InternalSingleNodeRouting<C> {
     #[default]
     Random,
     SpecificNode(Route),
+    SpecificNodeWithPreferred {
+        route: Route,
+        preferred: NodeAddress,
+    },
     ByAddress(NodeAddress),
+    ByAddressTransient(NodeAddress),
+    #[allow(dead_code)]
     Connection {
         identifier: NodeAddress,
         conn: C,
@@ -54,12 +60,32 @@ pub(super) enum InternalSingleNodeRouting<C> {
     },
 }
 
+impl<C> InternalSingleNodeRouting<C> {
+    pub(super) fn is_transient(&self) -> bool {
+        match self {
+            Self::ByAddressTransient(_) => true,
+            Self::Redirect {
+                previous_routing, ..
+            } => previous_routing.is_transient(),
+            _ => false,
+        }
+    }
+}
+
 impl<C> std::fmt::Debug for InternalSingleNodeRouting<C> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Random => write!(f, "Random"),
             Self::SpecificNode(arg0) => f.debug_tuple("SpecificNode").field(arg0).finish(),
+            Self::SpecificNodeWithPreferred { route, preferred } => f
+                .debug_struct("SpecificNodeWithPreferred")
+                .field("route", route)
+                .field("preferred", preferred)
+                .finish(),
             Self::ByAddress(arg0) => f.debug_tuple("ByAddress").field(arg0).finish(),
+            Self::ByAddressTransient(arg0) => {
+                f.debug_tuple("ByAddressTransient").field(arg0).finish()
+            }
             Self::Connection {
                 identifier,
                 conn: _conn,

--- a/redis/src/cluster_handling/client.rs
+++ b/redis/src/cluster_handling/client.rs
@@ -483,7 +483,7 @@ impl ClusterClientBuilder {
     /// The blanket implementation uses default to construct a new strategy for each connection.
     ///
     /// The `cluster_read_routing` module provides built-in simple strategies such as
-    /// `RandomReplicaStrategy` and `RoundRobinReplicaStrategy`.
+    /// `RandomReplicaStrategy`, `UniformRandom`, and `RoundRobinReplicaStrategy`.
     ///
     /// You can implement your own `ReadRoutingStrategy` using the provided traits.
     ///

--- a/redis/src/cluster_handling/read_routing/interface.rs
+++ b/redis/src/cluster_handling/read_routing/interface.rs
@@ -442,6 +442,25 @@ pub trait ReadRoutingStrategy: Send + Sync {
         None
     }
 
+    /// Notifies the strategy after the cluster connection's live node set changes.
+    ///
+    /// This callback is intended for strategies that deliberately keep only a
+    /// topology subset connected and need to avoid repeatedly selecting an eager
+    /// node whose connection could not be established. The default implementation
+    /// does nothing.
+    #[doc(hidden)]
+    fn on_connections_changed(&self, _connected_nodes: &HashSet<NodeAddress>) {}
+
+    /// Notifies the strategy that an on-demand node connection was added.
+    #[doc(hidden)]
+    fn on_connection_added(&self, _connected_node: &NodeAddress) {}
+
+    /// Returns whether failed read requests should try other shard candidates.
+    #[doc(hidden)]
+    fn supports_read_fallback(&self) -> bool {
+        false
+    }
+
     /// Choose which node within a shard to route a read command to.
     ///
     /// The returned reference must point to one of the addresses provided in

--- a/redis/src/cluster_handling/read_routing/mod.rs
+++ b/redis/src/cluster_handling/read_routing/mod.rs
@@ -5,6 +5,9 @@
 //! which node within a shard should handle each read — for example picking
 //! a random replica, round-robin across replicas, or selecting the
 //! lowest-latency node.
+//! `UniformRandom` gives each cluster connection stable affinity to one
+//! uniformly selected replica per shard, reducing its steady-state replica
+//! connection fan-out.
 //!
 //! This module contains the trait definitions for implementing custom
 //! strategies and some built-in strategies.
@@ -14,6 +17,7 @@
 mod interface;
 mod random_replica;
 mod round_robin_replica;
+mod uniform_random;
 mod zonal_read_routing;
 
 pub use interface::{
@@ -24,4 +28,5 @@ pub use interface::{
 };
 pub use random_replica::RandomReplicaStrategy;
 pub use round_robin_replica::RoundRobinReplicaStrategy;
+pub use uniform_random::UniformRandom;
 pub use zonal_read_routing::ZonalReadRoutingStrategy;

--- a/redis/src/cluster_handling/read_routing/uniform_random.rs
+++ b/redis/src/cluster_handling/read_routing/uniform_random.rs
@@ -1,0 +1,392 @@
+use std::collections::{HashSet, hash_map::DefaultHasher};
+use std::hash::{Hash, Hasher};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, RwLock};
+
+use rand::Rng;
+
+use super::interface::{ClusterTopology, ReadCandidates, ReadRoutingStrategy};
+use crate::cluster_handling::NodeAddress;
+use crate::cluster_handling::slot_range_map::SlotRangeMap;
+
+struct ShardSelection {
+    selected_replica: Option<NodeAddress>,
+    replicas: Arc<[NodeAddress]>,
+    // One-based index into `replicas`; zero means no replica is connected.
+    active_replica: AtomicUsize,
+}
+
+impl ShardSelection {
+    fn new(selected_replica: Option<NodeAddress>, replicas: &[NodeAddress]) -> Self {
+        let active_replica = selected_replica
+            .as_ref()
+            .and_then(|selected| replicas.iter().position(|replica| replica == selected))
+            .map_or(0, |index| index + 1);
+        Self {
+            selected_replica,
+            replicas: replicas.into(),
+            active_replica: AtomicUsize::new(active_replica),
+        }
+    }
+
+    fn update_connected_nodes(&self, connected_nodes: &HashSet<NodeAddress>) {
+        let active_replica = self
+            .selected_replica
+            .as_ref()
+            .filter(|selected| connected_nodes.contains(*selected))
+            .and_then(|selected| self.replicas.iter().position(|replica| replica == selected))
+            .or_else(|| {
+                self.replicas
+                    .iter()
+                    .position(|replica| connected_nodes.contains(replica))
+            })
+            .map_or(0, |index| index + 1);
+        self.active_replica.store(active_replica, Ordering::Relaxed);
+    }
+
+    fn mark_connected(&self, connected_node: &NodeAddress) {
+        let current = self.active_replica.load(Ordering::Relaxed);
+        let connected_index = self
+            .replicas
+            .iter()
+            .position(|replica| replica == connected_node)
+            .map(|index| index + 1);
+        let selected_index = self
+            .selected_replica
+            .as_ref()
+            .and_then(|selected| self.replicas.iter().position(|replica| replica == selected))
+            .map(|index| index + 1);
+
+        if let Some(connected_index) = connected_index {
+            if current == 0 || Some(connected_index) == selected_index {
+                self.active_replica
+                    .store(connected_index, Ordering::Relaxed);
+            }
+        }
+    }
+
+    fn active_replica(&self) -> Option<&NodeAddress> {
+        self.active_replica
+            .load(Ordering::Relaxed)
+            .checked_sub(1)
+            .and_then(|index| self.replicas.get(index))
+    }
+}
+
+/// Gives each cluster connection affinity to one uniformly selected replica per shard.
+///
+/// A connection-specific random seed and rendezvous hashing choose the replica. This
+/// keeps the choice stable across unchanged topology refreshes, avoids depending on
+/// replica ordering, and only remaps the connections affected by replica membership
+/// changes.
+///
+/// For normal keyed commands, the strategy eagerly maintains every primary plus one
+/// replica per shard. Commands routed to all nodes use transient connections for omitted
+/// replicas. Explicit-address routing, redirects, and failure recovery can still open a
+/// retained connection on demand; a later topology refresh restores the eager set.
+///
+/// If the selected replica is not connected, optional reads use the primary instead of
+/// opening a new connection on every request. Replica-required reads keep trying a
+/// replica, and any already-connected replica is preferred. The original affinity is
+/// restored when its connection becomes available again.
+pub struct UniformRandom {
+    seed: u64,
+    slots: Arc<RwLock<SlotRangeMap<Arc<ShardSelection>>>>,
+}
+
+impl UniformRandom {
+    /// Creates a new `UniformRandom` read-routing strategy factory.
+    ///
+    /// Each cluster connection created from this factory receives an independent
+    /// random seed and therefore makes independent per-shard replica selections.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[cfg(test)]
+    fn with_seed(seed: u64) -> Self {
+        Self {
+            seed,
+            slots: Arc::new(RwLock::new(SlotRangeMap::new())),
+        }
+    }
+
+    #[cfg(test)]
+    fn selected_replica_for_slot(&self, slot: u16) -> Option<NodeAddress> {
+        self.slots
+            .read()
+            .expect("Lock poisoned")
+            .get(slot)
+            .and_then(|selection| selection.selected_replica.clone())
+    }
+}
+
+impl Default for UniformRandom {
+    fn default() -> Self {
+        Self {
+            seed: rand::rng().random(),
+            slots: Arc::new(RwLock::new(SlotRangeMap::new())),
+        }
+    }
+}
+
+fn replica_score(seed: u64, primary: &NodeAddress, replica: &NodeAddress) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    seed.hash(&mut hasher);
+    primary.hash(&mut hasher);
+    replica.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn choose_uniform_replica(
+    seed: u64,
+    primary: &NodeAddress,
+    replicas: &[NodeAddress],
+) -> Option<NodeAddress> {
+    replicas
+        .iter()
+        .max_by(|left, right| {
+            replica_score(seed, primary, left)
+                .cmp(&replica_score(seed, primary, right))
+                .then_with(|| left.cmp(right))
+        })
+        .cloned()
+}
+
+impl ReadRoutingStrategy for UniformRandom {
+    fn on_topology_changed(&self, topology: ClusterTopology) {
+        let mut slots = SlotRangeMap::new();
+        for shard in topology.shards() {
+            let selection = Arc::new(ShardSelection::new(
+                choose_uniform_replica(self.seed, shard.primary(), shard.replicas()),
+                shard.replicas(),
+            ));
+            for &(start, end) in shard.slot_ranges() {
+                slots.insert(start, end, Arc::clone(&selection));
+            }
+        }
+
+        *self.slots.write().expect("Lock poisoned") = slots;
+    }
+
+    fn eager_connection_nodes(&self, topology: &ClusterTopology) -> Option<HashSet<NodeAddress>> {
+        let mut nodes = HashSet::new();
+        for shard in topology.shards() {
+            nodes.insert(shard.primary().clone());
+            nodes.extend(choose_uniform_replica(
+                self.seed,
+                shard.primary(),
+                shard.replicas(),
+            ));
+        }
+        Some(nodes)
+    }
+
+    fn on_connections_changed(&self, connected_nodes: &HashSet<NodeAddress>) {
+        for selection in self.slots.read().expect("Lock poisoned").values() {
+            selection.update_connected_nodes(connected_nodes);
+        }
+    }
+
+    fn on_connection_added(&self, connected_node: &NodeAddress) {
+        for selection in self.slots.read().expect("Lock poisoned").values() {
+            selection.mark_connected(connected_node);
+        }
+    }
+
+    fn supports_read_fallback(&self) -> bool {
+        true
+    }
+
+    fn route_read<'a>(&self, candidates: &ReadCandidates<'a>) -> &'a NodeAddress {
+        let slots = self.slots.read().expect("Lock poisoned");
+        let selection = slots.get(candidates.slot());
+        let active_replica = selection.and_then(|selection| selection.active_replica());
+        let selected_replica = selection.and_then(|selection| selection.selected_replica.as_ref());
+
+        match candidates {
+            ReadCandidates::AnyNode(c) => active_replica
+                .and_then(|active| c.replicas().iter().find(|replica| *replica == active))
+                .unwrap_or_else(|| c.primary()),
+            ReadCandidates::ReplicasOnly(c) => active_replica
+                .or(selected_replica)
+                .and_then(|selected| c.replicas().iter().find(|replica| *replica == selected))
+                .unwrap_or_else(|| c.replicas().first()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cluster_handling::read_routing::{Replicas, Shard};
+
+    fn node(host: &str, port: u16) -> NodeAddress {
+        NodeAddress::from_parts(host.into(), port)
+    }
+
+    fn topology() -> ClusterTopology {
+        ClusterTopology::from_shards(vec![
+            Shard::new(
+                vec![(0, 1000)],
+                node("primary1", 6379),
+                vec![
+                    node("replica1a", 6379),
+                    node("replica1b", 6379),
+                    node("replica1c", 6379),
+                ],
+            ),
+            Shard::new(
+                vec![(1001, 2000)],
+                node("primary2", 6379),
+                vec![node("replica2a", 6379), node("replica2b", 6379)],
+            ),
+        ])
+    }
+
+    #[test]
+    fn eagerly_connects_to_all_primaries_and_one_replica_per_shard() {
+        let strategy = UniformRandom::with_seed(42);
+        let topology = topology();
+        strategy.on_topology_changed(topology.clone());
+
+        let eager_nodes = strategy.eager_connection_nodes(&topology).unwrap();
+        assert_eq!(eager_nodes.len(), 4);
+        for shard in topology.shards() {
+            assert!(eager_nodes.contains(shard.primary()));
+            assert_eq!(
+                shard
+                    .replicas()
+                    .iter()
+                    .filter(|replica| eager_nodes.contains(*replica))
+                    .count(),
+                1
+            );
+            let selected = strategy
+                .selected_replica_for_slot(shard.slot_ranges()[0].0)
+                .unwrap();
+            assert!(eager_nodes.contains(&selected));
+        }
+    }
+
+    #[test]
+    fn routes_to_the_eagerly_selected_replica() {
+        let strategy = UniformRandom::with_seed(42);
+        strategy.on_topology_changed(topology());
+
+        let selected = strategy.selected_replica_for_slot(1).unwrap();
+        let primary = node("primary1", 6379);
+        let replicas = [
+            node("replica1a", 6379),
+            node("replica1b", 6379),
+            node("replica1c", 6379),
+        ];
+        let candidates = ReadCandidates::any_node(1, &primary, Replicas::new(&replicas).unwrap());
+
+        assert_eq!(strategy.route_read(&candidates), &selected);
+    }
+
+    #[test]
+    fn routes_around_an_unavailable_selected_replica_without_losing_affinity() {
+        let strategy = UniformRandom::with_seed(42);
+        strategy.on_topology_changed(topology());
+
+        let primary = node("primary1", 6379);
+        let replicas = [
+            node("replica1a", 6379),
+            node("replica1b", 6379),
+            node("replica1c", 6379),
+        ];
+        let selected = strategy.selected_replica_for_slot(1).unwrap();
+        let fallback = replicas
+            .iter()
+            .find(|replica| *replica != &selected)
+            .unwrap()
+            .clone();
+
+        strategy.on_connections_changed(&HashSet::from([primary.clone()]));
+        let any_node = ReadCandidates::any_node(
+            1,
+            &primary,
+            Replicas::new(&replicas).expect("replicas are non-empty"),
+        );
+        let replicas_only = ReadCandidates::replicas_only(
+            1,
+            Replicas::new(&replicas).expect("replicas are non-empty"),
+        );
+        assert_eq!(strategy.route_read(&any_node), &primary);
+        assert_eq!(strategy.route_read(&replicas_only), &selected);
+
+        strategy.on_connections_changed(&HashSet::from([primary.clone(), fallback.clone()]));
+        assert_eq!(strategy.route_read(&any_node), &fallback);
+        assert_eq!(strategy.route_read(&replicas_only), &fallback);
+
+        strategy.on_connections_changed(&HashSet::from([primary.clone(), selected.clone()]));
+        assert_eq!(strategy.route_read(&any_node), &selected);
+    }
+
+    #[test]
+    fn selection_is_stable_across_refresh_and_replica_order() {
+        let strategy = UniformRandom::with_seed(42);
+        strategy.on_topology_changed(topology());
+        let selected = strategy.selected_replica_for_slot(1);
+
+        strategy.on_topology_changed(ClusterTopology::from_shards(vec![Shard::new(
+            vec![(0, 500), (1000, 1500)],
+            node("primary1", 6379),
+            vec![
+                node("replica1c", 6379),
+                node("replica1a", 6379),
+                node("replica1b", 6379),
+            ],
+        )]));
+
+        assert_eq!(strategy.selected_replica_for_slot(1), selected);
+        assert_eq!(strategy.selected_replica_for_slot(1200), selected);
+    }
+
+    #[test]
+    fn adding_a_replica_only_remaps_seeds_that_select_the_new_replica() {
+        let primary = node("primary", 6379);
+        let old_replicas = [node("replica-a", 6379), node("replica-b", 6379)];
+        let new_replica = node("replica-c", 6379);
+        let new_replicas = [
+            old_replicas[0].clone(),
+            old_replicas[1].clone(),
+            new_replica.clone(),
+        ];
+
+        for seed in 0..1024 {
+            let old = choose_uniform_replica(seed, &primary, &old_replicas).unwrap();
+            let new = choose_uniform_replica(seed, &primary, &new_replicas).unwrap();
+            if new != new_replica {
+                assert_eq!(new, old);
+            }
+        }
+    }
+
+    #[test]
+    fn selection_is_uniform_across_connection_seeds() {
+        let primary = node("primary", 6379);
+        let replicas = [
+            node("replica-a", 6379),
+            node("replica-b", 6379),
+            node("replica-c", 6379),
+        ];
+        let mut counts = [0usize; 3];
+
+        for seed in 0..4096 {
+            let selected = choose_uniform_replica(seed, &primary, &replicas).unwrap();
+            let index = replicas
+                .iter()
+                .position(|replica| replica == &selected)
+                .unwrap();
+            counts[index] += 1;
+        }
+
+        let expected = 4096 / replicas.len();
+        for count in counts {
+            assert!(count.abs_diff(expected) < expected / 10, "{counts:?}");
+        }
+    }
+}

--- a/redis/src/cluster_handling/slot_map.rs
+++ b/redis/src/cluster_handling/slot_map.rs
@@ -53,6 +53,18 @@ impl SlotMap {
             .map(|addrs| addrs.slot_addr(slot, &route.slot_addr(), strategy))
     }
 
+    pub(crate) fn slot_addr_for_route_excluding(
+        &self,
+        route: &Route,
+        strategy: Option<&dyn ReadRoutingStrategy>,
+        excluded_nodes: &[NodeAddress],
+    ) -> Option<&NodeAddress> {
+        let slot = route.slot();
+        self.slots.get(slot).and_then(|addrs| {
+            addrs.slot_addr_excluding(slot, &route.slot_addr(), strategy, excluded_nodes)
+        })
+    }
+
     #[cfg(feature = "cluster-async")]
     pub fn clear(&mut self) {
         self.slots.clear();
@@ -88,6 +100,7 @@ impl SlotMap {
         self.all_unique_addresses(false)
     }
 
+    #[cfg(any(feature = "cluster-async", test))]
     pub fn addresses_for_multi_slot<'a, 'b>(
         &'a self,
         routes: &'b [(Route, Vec<usize>)],
@@ -146,6 +159,61 @@ pub(crate) struct SlotAddrs {
 impl SlotAddrs {
     pub(crate) fn new(primary: NodeAddress, replicas: Vec<NodeAddress>) -> Self {
         Self { primary, replicas }
+    }
+
+    pub(crate) fn slot_addr_excluding(
+        &self,
+        slot: u16,
+        slot_addr: &SlotAddr,
+        strategy: Option<&dyn ReadRoutingStrategy>,
+        excluded_nodes: &[NodeAddress],
+    ) -> Option<&NodeAddress> {
+        if excluded_nodes.is_empty() {
+            return Some(self.slot_addr(slot, slot_addr, strategy));
+        }
+
+        match slot_addr {
+            SlotAddr::Master => (!excluded_nodes.contains(&self.primary)).then_some(&self.primary),
+            SlotAddr::ReplicaOptional => {
+                let selected = match (strategy, Replicas::new(&self.replicas)) {
+                    (Some(strategy), Some(replicas)) => strategy
+                        .route_read(&ReadCandidates::any_node(slot, &self.primary, replicas)),
+                    _ => &self.primary,
+                };
+                if !excluded_nodes.contains(selected) {
+                    return Some(selected);
+                }
+
+                (!excluded_nodes.contains(&self.primary))
+                    .then_some(&self.primary)
+                    .or_else(|| {
+                        strategy.and_then(|_| {
+                            self.replicas
+                                .iter()
+                                .find(|replica| !excluded_nodes.contains(*replica))
+                        })
+                    })
+            }
+            SlotAddr::ReplicaRequired => {
+                let Some(replicas) = Replicas::new(&self.replicas) else {
+                    return (!excluded_nodes.contains(&self.primary)).then_some(&self.primary);
+                };
+                let selected = match strategy {
+                    Some(strategy) => strategy.route_read(&ReadCandidates::replicas_only(
+                        slot,
+                        Replicas::new(&self.replicas).expect("replicas are non-empty"),
+                    )),
+                    None => replicas.choose_random(),
+                };
+                if !excluded_nodes.contains(selected) {
+                    return Some(selected);
+                }
+
+                self.replicas
+                    .iter()
+                    .find(|replica| !excluded_nodes.contains(*replica))
+            }
+        }
     }
 
     pub(crate) fn slot_addr(
@@ -353,6 +421,68 @@ mod tests {
                 )
                 .unwrap(),
             "replica1:6379"
+        );
+    }
+
+    #[test]
+    fn test_slot_map_read_fallback_respects_route_semantics() {
+        let strategy = FirstReplicaStrategy;
+        let slot_map = SlotMap::from_slots(vec![SlotRange::new(
+            1,
+            1000,
+            addr("primary:6379"),
+            vec![addr("replica1:6379"), addr("replica2:6379")],
+        )]);
+        let optional = Route::with_slot(Slot::new(500).unwrap(), SlotAddr::ReplicaOptional);
+        let required = Route::with_slot(Slot::new(500).unwrap(), SlotAddr::ReplicaRequired);
+
+        assert_eq!(
+            slot_map.slot_addr_for_route_excluding(
+                &optional,
+                Some(&strategy),
+                &[addr("replica1:6379")],
+            ),
+            Some(&addr("primary:6379"))
+        );
+        assert_eq!(
+            slot_map.slot_addr_for_route_excluding(
+                &optional,
+                Some(&strategy),
+                &[addr("replica1:6379"), addr("primary:6379")],
+            ),
+            Some(&addr("replica2:6379"))
+        );
+        assert_eq!(
+            slot_map.slot_addr_for_route_excluding(
+                &required,
+                Some(&strategy),
+                &[addr("replica1:6379")],
+            ),
+            Some(&addr("replica2:6379"))
+        );
+        assert_eq!(
+            slot_map.slot_addr_for_route_excluding(
+                &required,
+                Some(&strategy),
+                &[addr("replica1:6379"), addr("replica2:6379")],
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn test_slot_map_without_strategy_does_not_fall_back_to_unprepared_replica() {
+        let slot_map = SlotMap::from_slots(vec![SlotRange::new(
+            1,
+            1000,
+            addr("primary:6379"),
+            vec![addr("replica:6379")],
+        )]);
+        let optional = Route::with_slot(Slot::new(500).unwrap(), SlotAddr::ReplicaOptional);
+
+        assert_eq!(
+            slot_map.slot_addr_for_route_excluding(&optional, None, &[addr("primary:6379")],),
+            None
         );
     }
 

--- a/redis/src/cluster_handling/sync_connection/mod.rs
+++ b/redis/src/cluster_handling/sync_connection/mod.rs
@@ -1201,13 +1201,17 @@ where
                     )))?;
                 let cmd =
                     crate::cluster_routing::command_for_multi_slot_indices(&input, indices.iter());
-                let routing = Some(RoutingInfo::SingleNode(
-                    SingleNodeRoutingInfo::SpecificNode(*route),
-                ));
                 let response = if self.uses_read_fallback(route) {
+                    let routing = Some(RoutingInfo::SingleNode(
+                        SingleNodeRoutingInfo::SpecificNode(*route),
+                    ));
                     self.request_with_preferred_addr(Input::Cmd(&cmd), routing, addr.clone())
                 } else {
-                    self.request(Input::Cmd(&cmd), routing)
+                    // Stateful strategies must dispatch the address selected above instead of
+                    // resolving the route a second time.
+                    let mut connections = self.connections.borrow_mut();
+                    self.get_connection_by_addr(&mut connections, &addr)
+                        .and_then(|connection| Input::Cmd(&cmd).send(connection))
                 };
                 response.map(|res| match res {
                     Output::Single(value) => (addr, value),

--- a/redis/src/cluster_handling/sync_connection/mod.rs
+++ b/redis/src/cluster_handling/sync_connection/mod.rs
@@ -332,6 +332,7 @@ pub struct ClusterConnection<C = Connection> {
     read_timeout: RefCell<Option<Duration>>,
     write_timeout: RefCell<Option<Duration>>,
     routing_strategy: Option<Box<dyn ReadRoutingStrategy>>,
+    read_fallback_enabled: bool,
     az_discovery: Arc<NodeAvailabilityZoneDiscoveryState>,
     cluster_params: ClusterParams,
 }
@@ -380,6 +381,9 @@ where
             .read_routing_factory
             .as_ref()
             .map(|f| f.create_strategy());
+        let read_fallback_enabled = routing_strategy
+            .as_deref()
+            .is_some_and(ReadRoutingStrategy::supports_read_fallback);
 
         let connection = Self {
             connections: RefCell::new(HashMap::new()),
@@ -388,6 +392,7 @@ where
             read_timeout: RefCell::new(cluster_params.response_timeout),
             write_timeout: RefCell::new(None),
             routing_strategy,
+            read_fallback_enabled,
             az_discovery: Arc::new(NodeAvailabilityZoneDiscoveryState::default()),
             initial_nodes: initial_nodes.to_vec(),
             cluster_params,
@@ -638,6 +643,7 @@ where
         }
 
         *connections = refreshed;
+        self.notify_connections_changed(&connections);
     }
 
     fn create_new_slots(&self) -> RedisResult<SlotMap> {
@@ -893,9 +899,152 @@ where
         if let Some(addr) = slots.slot_addr_for_route(route, self.routing_strategy.as_deref()) {
             (addr.clone(), self.get_connection_by_addr(connections, addr))
         } else {
-            // try a random node next.  This is safe if slots are involved
+            // try a random node next. This is safe if slots are involved
             // as a wrong node would reject the request.
             get_random_connection_or_error(connections)
+        }
+    }
+
+    fn get_connection_excluding<'a>(
+        &self,
+        connections: &'a mut HashMap<NodeAddress, C>,
+        route: &Route,
+        excluded_nodes: &mut Vec<NodeAddress>,
+        mut preferred_addr: Option<NodeAddress>,
+    ) -> (NodeAddress, RedisResult<&'a mut C>) {
+        if route.slot_addr() == SlotAddr::ReplicaRequired {
+            return self.get_connection_excluding_slow(
+                connections,
+                route,
+                excluded_nodes,
+                preferred_addr,
+            );
+        }
+
+        if excluded_nodes.is_empty() {
+            let addr = preferred_addr.take().or_else(|| {
+                self.slots
+                    .borrow()
+                    .slot_addr_for_route(route, self.routing_strategy.as_deref())
+                    .cloned()
+            });
+            if let Some(addr) = addr {
+                let connection = self.get_connection_by_addr(connections, &addr);
+                return (addr, connection);
+            }
+        }
+
+        self.get_connection_excluding_slow(connections, route, excluded_nodes, preferred_addr)
+    }
+
+    fn get_connection_excluding_slow<'a>(
+        &self,
+        connections: &'a mut HashMap<NodeAddress, C>,
+        route: &Route,
+        excluded_nodes: &mut Vec<NodeAddress>,
+        mut preferred_addr: Option<NodeAddress>,
+    ) -> (NodeAddress, RedisResult<&'a mut C>) {
+        let mut last_failure = None;
+
+        loop {
+            let addr = {
+                let slots = self.slots.borrow();
+                preferred_addr
+                    .take()
+                    .filter(|addr| !excluded_nodes.contains(addr))
+                    .or_else(|| {
+                        slots
+                            .slot_addr_for_route_excluding(
+                                route,
+                                self.routing_strategy.as_deref(),
+                                excluded_nodes,
+                            )
+                            .cloned()
+                    })
+            };
+
+            let Some(addr) = addr else {
+                return match last_failure {
+                    Some((addr, err)) => (addr, Err(err)),
+                    None if excluded_nodes.is_empty() => {
+                        get_random_connection_or_error(connections)
+                    }
+                    None => (
+                        NodeAddress::default(),
+                        Err(RedisError::from((
+                            ErrorKind::ClusterConnectionNotFound,
+                            "No eligible read connection found",
+                        ))),
+                    ),
+                };
+            };
+
+            match self.ensure_connection_by_addr(connections, &addr) {
+                Ok(()) => {
+                    let return_addr = addr.clone();
+                    return (
+                        return_addr,
+                        connections.get_mut(&addr).ok_or_else(|| {
+                            RedisError::from((
+                                ErrorKind::ClusterConnectionNotFound,
+                                "Couldn't find connection",
+                            ))
+                        }),
+                    );
+                }
+                Err(err) => {
+                    if excluded_nodes.contains(&addr) {
+                        return (addr, Err(err));
+                    }
+                    excluded_nodes.push(addr.clone());
+                    last_failure = Some((addr, err));
+                }
+            }
+        }
+    }
+
+    fn ensure_connection_by_addr(
+        &self,
+        connections: &mut HashMap<NodeAddress, C>,
+        addr: &NodeAddress,
+    ) -> RedisResult<()> {
+        if connections.contains_key(addr) {
+            return Ok(());
+        }
+
+        let conn = self.connect(addr)?;
+        connections.insert(addr.clone(), conn);
+        if let Some(strategy) = &self.routing_strategy {
+            strategy.on_connection_added(addr);
+        }
+        Ok(())
+    }
+
+    fn notify_connections_changed(&self, connections: &HashMap<NodeAddress, C>) {
+        if let Some(strategy) = &self.routing_strategy {
+            let connected_nodes = connections.keys().cloned().collect();
+            strategy.on_connections_changed(&connected_nodes);
+        }
+    }
+
+    fn uses_read_fallback(&self, route: &Route) -> bool {
+        self.read_fallback_enabled
+            && matches!(
+                route.slot_addr(),
+                SlotAddr::ReplicaOptional | SlotAddr::ReplicaRequired
+            )
+    }
+
+    fn note_read_node_failure(
+        &self,
+        routing: &SingleNodeRoutingInfo,
+        addr: &NodeAddress,
+        excluded_nodes: &mut Vec<NodeAddress>,
+    ) {
+        if let SingleNodeRoutingInfo::SpecificNode(route) = routing {
+            if self.uses_read_fallback(route) && !excluded_nodes.contains(addr) {
+                excluded_nodes.push(addr.clone());
+            }
         }
     }
 
@@ -912,7 +1061,11 @@ where
                 // Create new connection.
                 // TODO: error handling
                 let conn = self.connect(addr)?;
-                Ok(vacant_entry.insert(conn))
+                let connection = vacant_entry.insert(conn);
+                if let Some(strategy) = &self.routing_strategy {
+                    strategy.on_connection_added(addr);
+                }
+                Ok(connection)
             }
         }
     }
@@ -957,11 +1110,11 @@ where
         Ok(result)
     }
 
-    fn execute_on_all<'a>(
-        &'a self,
+    fn execute_on_all(
+        &self,
         input: Input,
-        addresses: HashSet<&'a NodeAddress>,
-    ) -> Vec<RedisResult<(&'a NodeAddress, Value)>> {
+        addresses: HashSet<NodeAddress>,
+    ) -> Vec<RedisResult<(NodeAddress, Value)>> {
         addresses
             .into_iter()
             .map(|addr| {
@@ -981,45 +1134,85 @@ where
             .collect()
     }
 
-    fn execute_on_all_nodes<'a>(
-        &'a self,
-        input: Input,
-        slots: &'a mut SlotMap,
-    ) -> Vec<RedisResult<(&'a NodeAddress, Value)>> {
-        self.execute_on_all(input, slots.addresses_for_all_nodes())
+    fn execute_on_all_nodes(&self, input: Input) -> Vec<RedisResult<(NodeAddress, Value)>> {
+        let preserved_connections = self.routing_strategy.as_ref().map(|_| {
+            self.connections
+                .borrow()
+                .keys()
+                .cloned()
+                .collect::<HashSet<_>>()
+        });
+        let addresses = self
+            .slots
+            .borrow()
+            .addresses_for_all_nodes()
+            .into_iter()
+            .cloned()
+            .collect();
+        let results = self.execute_on_all(input, addresses);
+        if let Some(preserved_connections) = preserved_connections {
+            self.prune_to_eager_connections(&preserved_connections);
+        }
+        results
     }
 
-    fn execute_on_all_primaries<'a>(
-        &'a self,
-        input: Input,
-        slots: &'a mut SlotMap,
-    ) -> Vec<RedisResult<(&'a NodeAddress, Value)>> {
-        self.execute_on_all(input, slots.addresses_for_all_primaries())
+    fn prune_to_eager_connections(&self, preserved_connections: &HashSet<NodeAddress>) {
+        let Some(strategy) = &self.routing_strategy else {
+            return;
+        };
+        let topology = self.slots.borrow().topology();
+        let Some(eager_nodes) = strategy.eager_connection_nodes(&topology) else {
+            return;
+        };
+        let mut connections = self.connections.borrow_mut();
+        connections.retain(|address, _| {
+            eager_nodes.contains(address) || preserved_connections.contains(address)
+        });
+        self.notify_connections_changed(&connections);
     }
 
-    fn execute_multi_slot<'a, 'b>(
-        &'a self,
+    fn execute_on_all_primaries(&self, input: Input) -> Vec<RedisResult<(NodeAddress, Value)>> {
+        let addresses = self
+            .slots
+            .borrow()
+            .addresses_for_all_primaries()
+            .into_iter()
+            .cloned()
+            .collect();
+        self.execute_on_all(input, addresses)
+    }
+
+    fn execute_multi_slot(
+        &self,
         input: Input,
-        slots: &'a mut SlotMap,
-        connections: &'a mut HashMap<NodeAddress, C>,
-        routes: &'b [(Route, Vec<usize>)],
-    ) -> Vec<RedisResult<(&'a NodeAddress, Value)>>
-    where
-        'b: 'a,
-    {
-        slots
-            .addresses_for_multi_slot(routes, self.routing_strategy.as_deref())
-            .enumerate()
-            .map(|(index, addr)| {
-                let addr = addr.ok_or(RedisError::from((
-                    ErrorKind::Io,
-                    "Couldn't find connection",
-                )))?;
-                let connection = self.get_connection_by_addr(connections, addr)?;
-                let (_, indices) = routes.get(index).unwrap();
+        routes: &[(Route, Vec<usize>)],
+    ) -> Vec<RedisResult<(NodeAddress, Value)>> {
+        routes
+            .iter()
+            .map(|(route, indices)| {
+                let addr = self
+                    .slots
+                    .borrow()
+                    .slot_addr_for_route(route, self.routing_strategy.as_deref())
+                    .cloned()
+                    .ok_or(RedisError::from((
+                        ErrorKind::Io,
+                        "Couldn't find connection",
+                    )))?;
                 let cmd =
                     crate::cluster_routing::command_for_multi_slot_indices(&input, indices.iter());
-                connection.req_command(&cmd).map(|res| (addr, res))
+                let routing = Some(RoutingInfo::SingleNode(
+                    SingleNodeRoutingInfo::SpecificNode(*route),
+                ));
+                let response = if self.uses_read_fallback(route) {
+                    self.request_with_preferred_addr(Input::Cmd(&cmd), routing, addr.clone())
+                } else {
+                    self.request(Input::Cmd(&cmd), routing)
+                };
+                response.map(|res| match res {
+                    Output::Single(value) => (addr, value),
+                    Output::Multi(values) => (addr, Value::Array(values)),
+                })
             })
             .collect()
     }
@@ -1030,21 +1223,12 @@ where
         routing: MultipleNodeRoutingInfo,
         response_policy: Option<ResponsePolicy>,
     ) -> RedisResult<Value> {
-        let mut connections = self.connections.borrow_mut();
-        let mut slots = self.slots.borrow_mut();
-
         let results = match &routing {
             MultipleNodeRoutingInfo::MultiSlot((routes, _)) => {
-                self.execute_multi_slot(input, &mut slots, &mut connections, routes)
+                self.execute_multi_slot(input, routes)
             }
-            MultipleNodeRoutingInfo::AllMasters => {
-                drop(connections);
-                self.execute_on_all_primaries(input, &mut slots)
-            }
-            MultipleNodeRoutingInfo::AllNodes => {
-                drop(connections);
-                self.execute_on_all_nodes(input, &mut slots)
-            }
+            MultipleNodeRoutingInfo::AllMasters => self.execute_on_all_primaries(input),
+            MultipleNodeRoutingInfo::AllNodes => self.execute_on_all_nodes(input),
         };
 
         match response_policy {
@@ -1150,8 +1334,33 @@ where
         }
     }
 
+    #[inline(always)]
     #[allow(clippy::unnecessary_unwrap)]
     fn request(&self, input: Input, route_option: Option<RoutingInfo>) -> RedisResult<Output> {
+        if self.read_fallback_enabled {
+            self.request_inner::<true, false>(input, route_option, None)
+        } else {
+            self.request_inner::<false, false>(input, route_option, None)
+        }
+    }
+
+    #[inline(always)]
+    fn request_with_preferred_addr(
+        &self,
+        input: Input,
+        route_option: Option<RoutingInfo>,
+        preferred_addr: NodeAddress,
+    ) -> RedisResult<Output> {
+        self.request_inner::<true, true>(input, route_option, Some(preferred_addr))
+    }
+
+    #[allow(clippy::unnecessary_unwrap)]
+    fn request_inner<const READ_FALLBACK: bool, const HAS_PREFERRED_ADDR: bool>(
+        &self,
+        input: Input,
+        route_option: Option<RoutingInfo>,
+        mut preferred_addr: Option<NodeAddress>,
+    ) -> RedisResult<Output> {
         let single_node_routing = match route_option {
             Some(RoutingInfo::SingleNode(single_node_routing)) => single_node_routing,
             Some(RoutingInfo::MultiNode((multi_node_routing, response_policy))) => {
@@ -1164,6 +1373,7 @@ where
 
         let mut retries = 0;
         let mut redirected = None::<Redirect>;
+        let mut excluded_read_nodes = Vec::new();
 
         loop {
             // Get target address and response.
@@ -1192,7 +1402,20 @@ where
                             get_random_connection_or_error(&mut connections)
                         }
                         SingleNodeRoutingInfo::SpecificNode(route) => {
-                            self.get_connection(&mut connections, route)
+                            if READ_FALLBACK && self.uses_read_fallback(route) {
+                                self.get_connection_excluding(
+                                    &mut connections,
+                                    route,
+                                    &mut excluded_read_nodes,
+                                    if HAS_PREFERRED_ADDR {
+                                        preferred_addr.take()
+                                    } else {
+                                        None
+                                    },
+                                )
+                            } else {
+                                self.get_connection(&mut connections, route)
+                            }
                         }
                         SingleNodeRoutingInfo::ByAddress { host, port } => {
                             let address = NodeAddress::new(host.as_str(), *port);
@@ -1252,20 +1475,37 @@ where
                             thread::sleep(sleep_time);
                         }
                         RetryMethod::Reconnect => {
+                            if READ_FALLBACK {
+                                self.note_read_node_failure(
+                                    &single_node_routing,
+                                    &addr,
+                                    &mut excluded_read_nodes,
+                                );
+                            }
                             if *self.auto_reconnect.borrow() {
                                 // if the connection is no longer valid, we should remove it.
-                                self.connections.borrow_mut().remove(&addr);
+                                let mut connections = self.connections.borrow_mut();
+                                connections.remove(&addr);
                                 if let Ok(mut conn) = self.connect(&addr) {
                                     if conn.check_connection() {
-                                        self.connections.borrow_mut().insert(addr, conn);
+                                        connections.insert(addr, conn);
                                     }
                                 }
+                                self.notify_connections_changed(&connections);
                             }
                         }
                         RetryMethod::NoRetry => {
                             return Err(err);
                         }
-                        RetryMethod::RetryImmediately => {}
+                        RetryMethod::RetryImmediately => {
+                            if READ_FALLBACK && err.kind() == ErrorKind::Io {
+                                self.note_read_node_failure(
+                                    &single_node_routing,
+                                    &addr,
+                                    &mut excluded_read_nodes,
+                                );
+                            }
+                        }
                         RetryMethod::ReconnectFromInitialConnections => {
                             // TODO - implement reconnect from initial connections
                             if *self.auto_reconnect.borrow() {

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -1445,6 +1445,52 @@ mod cluster {
     }
 
     #[test]
+    fn test_cluster_round_robin_multi_shard_read_advances_once_per_shard() {
+        let name = "test_cluster_round_robin_multi_shard_read_advances_once_per_shard";
+        let slots_config = vec![
+            MockSlotRange {
+                primary_port: 6379,
+                replica_ports: vec![6380, 6381],
+                slot_range: 0..8192,
+            },
+            MockSlotRange {
+                primary_port: 6382,
+                replica_ports: vec![6383, 6384],
+                slot_range: 8192..16384,
+            },
+        ];
+        let mut command = cmd("MGET");
+        command.arg("test").arg("{foo}test");
+        let MockEnv {
+            mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .retries(0)
+                .read_routing_strategy(RoundRobinReplicaStrategy::new()),
+            name,
+            move |received_cmd: &[u8], port| {
+                respond_startup_with_replica_using_config(
+                    name,
+                    received_cmd,
+                    Some(slots_config.clone()),
+                )?;
+                if contains_slice(received_cmd, b"MGET") {
+                    return Err(Ok(Value::Array(vec![redis_value!(port.to_string())])));
+                }
+                Ok(())
+            },
+        );
+
+        let first = command.query::<Vec<String>>(&mut connection).unwrap();
+        let second = command.query::<Vec<String>>(&mut connection).unwrap();
+
+        assert_eq!(first, vec!["6380", "6383"]);
+        assert_eq!(second, vec!["6381", "6384"]);
+    }
+
+    #[test]
     fn test_cluster_io_error() {
         let name = "test_cluster_io_error";
         let completed = Arc::new(AtomicI32::new(0));

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -14,9 +14,12 @@ mod cluster {
         Commands, ConnectionLike, ErrorKind, RedisError, ServerErrorKind, Value,
         cluster::{ClusterClient, ClusterConnection, cluster_pipe},
         cluster_read_routing::{
-            RandomReplicaStrategy, RoundRobinReplicaStrategy, ZonalReadRoutingStrategy,
+            RandomReplicaStrategy, RoundRobinReplicaStrategy, UniformRandom,
+            ZonalReadRoutingStrategy,
         },
-        cluster_routing::{MultipleNodeRoutingInfo, RoutingInfo, SingleNodeRoutingInfo},
+        cluster_routing::{
+            MultipleNodeRoutingInfo, Route, RoutingInfo, SingleNodeRoutingInfo, SlotAddr,
+        },
         cmd, parse_redis_value,
     };
     use redis_test::{
@@ -683,6 +686,250 @@ mod cluster {
             .arg("123")
             .query::<Option<Value>>(&mut connection);
         assert_eq!(value, Ok(Some(redis_value!(simple:"OK"))));
+    }
+
+    #[test]
+    fn test_cluster_uniform_random_connects_to_one_replica_per_shard() {
+        let name = "test_cluster_uniform_random_connects_to_one_replica_per_shard";
+        let slots_config = vec![
+            MockSlotRange {
+                primary_port: 6379,
+                replica_ports: vec![6380, 6381],
+                slot_range: 0..8192,
+            },
+            MockSlotRange {
+                primary_port: 6382,
+                replica_ports: vec![6383, 6384],
+                slot_range: 8192..16384,
+            },
+        ];
+        let command_ports = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let command_ports_clone = Arc::clone(&command_ports);
+
+        let MockEnv {
+            mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .read_routing_strategy(UniformRandom::new()),
+            name,
+            move |cmd: &[u8], port| {
+                respond_startup_with_replica_using_config(name, cmd, Some(slots_config.clone()))?;
+                if contains_slice(cmd, b"GET") {
+                    command_ports_clone.lock().unwrap().push(port);
+                    return Err(Ok(Value::Nil));
+                }
+                Ok(())
+            },
+        );
+
+        let connected_ports = connection
+            .connected_node_addresses()
+            .into_iter()
+            .map(|addr| addr.port())
+            .collect::<Vec<_>>();
+
+        assert!(connected_ports.contains(&6379));
+        assert!(connected_ports.contains(&6382));
+        assert_eq!(
+            connected_ports
+                .iter()
+                .filter(|port| matches!(**port, 6380 | 6381))
+                .count(),
+            1
+        );
+        assert_eq!(
+            connected_ports
+                .iter()
+                .filter(|port| matches!(**port, 6383 | 6384))
+                .count(),
+            1
+        );
+        assert_eq!(connected_ports.len(), 4);
+
+        connection
+            .route_command(
+                cmd("GET").arg("test"),
+                RoutingInfo::MultiNode((MultipleNodeRoutingInfo::AllNodes, None)),
+            )
+            .unwrap();
+        command_ports.lock().unwrap().sort_unstable();
+        assert_eq!(
+            *command_ports.lock().unwrap(),
+            vec![6379, 6380, 6381, 6382, 6383, 6384]
+        );
+        assert_eq!(connection.connected_node_count(), 4);
+    }
+
+    #[test]
+    fn test_cluster_uniform_random_falls_back_after_selected_replica_io_error() {
+        let name = "uniform_random_fallback";
+        let slots_config = vec![MockSlotRange {
+            primary_port: 6379,
+            replica_ports: vec![6380, 6381],
+            slot_range: 0..16384,
+        }];
+        let ports = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let ports_clone = ports.clone();
+        let failed_once = Arc::new(atomic::AtomicBool::new(false));
+        let failed_once_clone = failed_once.clone();
+
+        let MockEnv {
+            mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .retries(2)
+                .read_routing_strategy(UniformRandom::new()),
+            name,
+            move |cmd: &[u8], port| {
+                respond_startup_with_replica_using_config(name, cmd, Some(slots_config.clone()))?;
+
+                if contains_slice(cmd, b"GET") {
+                    ports_clone.lock().unwrap().push(port);
+                    if port != 6379 && !failed_once_clone.swap(true, Ordering::SeqCst) {
+                        return Err(Err(RedisError::from(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            "mock selected replica failure",
+                        ))));
+                    }
+                    return Err(Ok(redis_value!("123")));
+                }
+
+                Ok(())
+            },
+        );
+
+        let value = cmd("GET").arg("test").query::<Option<i32>>(&mut connection);
+
+        assert_eq!(value, Ok(Some(123)));
+        let recorded = ports.lock().unwrap().clone();
+        assert_eq!(recorded.len(), 2);
+        assert_ne!(recorded[0], 6379);
+        assert_eq!(recorded[1], 6379);
+        assert_eq!(connection.connected_node_count(), 2);
+    }
+
+    #[test]
+    fn test_cluster_uniform_random_falls_back_when_selected_replica_cannot_connect() {
+        let name = "uniform_random_connect_fallback";
+        let slots_config = vec![MockSlotRange {
+            primary_port: 6379,
+            replica_ports: vec![6380, 6381],
+            slot_range: 0..16384,
+        }];
+        let read_ports = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let read_ports_clone = Arc::clone(&read_ports);
+        let replica_connect_attempts = Arc::new(atomic::AtomicUsize::new(0));
+        let replica_connect_attempts_clone = Arc::clone(&replica_connect_attempts);
+
+        let MockEnv {
+            mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .retries(0)
+                .read_routing_strategy(UniformRandom::new()),
+            name,
+            move |cmd: &[u8], port| {
+                if contains_slice(cmd, b"READONLY") && port != 6379 {
+                    replica_connect_attempts_clone.fetch_add(1, Ordering::SeqCst);
+                    return Err(Err(RedisError::from(std::io::Error::new(
+                        std::io::ErrorKind::ConnectionRefused,
+                        "mock replica connect failure",
+                    ))));
+                }
+                respond_startup_with_replica_using_config(name, cmd, Some(slots_config.clone()))?;
+                if contains_slice(cmd, b"GET") {
+                    read_ports_clone.lock().unwrap().push(port);
+                    return Err(Ok(redis_value!("123")));
+                }
+                Ok(())
+            },
+        );
+
+        let attempts_after_startup = replica_connect_attempts.load(Ordering::SeqCst);
+        assert!(attempts_after_startup > 0);
+
+        for _ in 0..2 {
+            let value = cmd("GET").arg("test").query::<Option<i32>>(&mut connection);
+            assert_eq!(value, Ok(Some(123)));
+        }
+
+        assert_eq!(*read_ports.lock().unwrap(), vec![6379, 6379]);
+        assert_eq!(
+            replica_connect_attempts.load(Ordering::SeqCst),
+            attempts_after_startup
+        );
+        assert_eq!(connection.connected_node_count(), 1);
+    }
+
+    #[test]
+    fn test_cluster_uniform_random_replica_required_connects_to_another_replica() {
+        let name = "uniform_random_replica_required_connect_fallback";
+        let slots_config = vec![MockSlotRange {
+            primary_port: 6379,
+            replica_ports: vec![6380, 6381],
+            slot_range: 0..16384,
+        }];
+        let failed_replica = Arc::new(atomic::AtomicU16::new(0));
+        let failed_replica_clone = Arc::clone(&failed_replica);
+        let read_ports = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let read_ports_clone = Arc::clone(&read_ports);
+
+        let MockEnv {
+            mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .retries(0)
+                .read_routing_strategy(UniformRandom::new()),
+            name,
+            move |cmd: &[u8], port| {
+                if contains_slice(cmd, b"READONLY") && port != 6379 {
+                    let failed = failed_replica_clone
+                        .compare_exchange(0, port, Ordering::SeqCst, Ordering::SeqCst)
+                        .unwrap_or_else(|failed| failed);
+                    if failed == port || failed == 0 {
+                        return Err(Err(RedisError::from(std::io::Error::new(
+                            std::io::ErrorKind::ConnectionRefused,
+                            "mock selected replica connect failure",
+                        ))));
+                    }
+                }
+                respond_startup_with_replica_using_config(name, cmd, Some(slots_config.clone()))?;
+                if contains_slice(cmd, b"GET") {
+                    read_ports_clone.lock().unwrap().push(port);
+                    return Err(Ok(redis_value!("123")));
+                }
+                Ok(())
+            },
+        );
+
+        let failed_replica = failed_replica.load(Ordering::SeqCst);
+        assert!(matches!(failed_replica, 6380 | 6381));
+        let mut command = cmd("GET");
+        command.arg("test");
+        let value = connection
+            .route_command(
+                &command,
+                RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(Route::with_key(
+                    "test",
+                    SlotAddr::ReplicaRequired,
+                ))),
+            )
+            .unwrap();
+
+        assert_eq!(value, redis_value!("123"));
+        let read_ports = read_ports.lock().unwrap();
+        assert_eq!(read_ports.len(), 1);
+        assert_ne!(read_ports[0], 6379);
+        assert_ne!(read_ports[0], failed_replica);
+        assert_eq!(connection.connected_node_count(), 2);
     }
 
     #[test]
@@ -1402,6 +1649,53 @@ mod cluster {
 
         let result = cmd.query::<Vec<String>>(&mut connection).unwrap();
         assert_eq!(result, vec!["foo-6382", "bar-6380", "baz-6380"]);
+    }
+
+    #[test]
+    fn test_cluster_uniform_random_multi_shard_read_falls_back_to_primaries() {
+        let name = "uniform_random_multi_shard_fallback";
+        let replica_connect_attempts = Arc::new(atomic::AtomicUsize::new(0));
+        let replica_connect_attempts_clone = Arc::clone(&replica_connect_attempts);
+        let mut command = cmd("MGET");
+        command.arg("foo").arg("bar").arg("baz");
+        let MockEnv {
+            mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .retries(0)
+                .read_routing_strategy(UniformRandom::new()),
+            name,
+            move |received_cmd: &[u8], port| {
+                if contains_slice(received_cmd, b"READONLY") && matches!(port, 6380 | 6382) {
+                    replica_connect_attempts_clone.fetch_add(1, Ordering::SeqCst);
+                    return Err(Err(RedisError::from(std::io::Error::new(
+                        std::io::ErrorKind::ConnectionRefused,
+                        "mock replica connect failure",
+                    ))));
+                }
+                respond_startup_with_replica_using_config(name, received_cmd, None)?;
+                let cmd_str = std::str::from_utf8(received_cmd).unwrap();
+                let results = ["foo", "bar", "baz"]
+                    .iter()
+                    .filter(|expected_key| cmd_str.contains(*expected_key))
+                    .map(|expected_key| redis_value!(format!("{expected_key}-{port}")))
+                    .collect();
+                Err(Ok(Value::Array(results)))
+            },
+        );
+
+        let attempts_after_startup = replica_connect_attempts.load(Ordering::SeqCst);
+        assert!(attempts_after_startup >= 2);
+        for _ in 0..2 {
+            let result = command.query::<Vec<String>>(&mut connection).unwrap();
+            assert_eq!(result, vec!["foo-6381", "bar-6379", "baz-6379"]);
+        }
+        assert_eq!(
+            replica_connect_attempts.load(Ordering::SeqCst),
+            attempts_after_startup
+        );
     }
 
     #[test]

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -4,10 +4,10 @@ mod support;
 #[cfg(test)]
 mod cluster_async {
     use std::{
-        collections::HashMap,
+        collections::{HashMap, HashSet},
         sync::{
             Arc, LazyLock,
-            atomic::{self, AtomicBool, AtomicI32, AtomicU16, AtomicU32, Ordering},
+            atomic::{self, AtomicBool, AtomicI32, AtomicU16, AtomicU32, AtomicUsize, Ordering},
         },
         time::Duration,
     };
@@ -22,7 +22,7 @@ mod cluster_async {
         aio::{ConnectionLike, MultiplexedConnection},
         cluster::ClusterClient,
         cluster_async::Connect,
-        cluster_read_routing::{RandomReplicaStrategy, RoundRobinReplicaStrategy},
+        cluster_read_routing::{RandomReplicaStrategy, RoundRobinReplicaStrategy, UniformRandom},
         cluster_routing::{
             MultipleNodeRoutingInfo, ResponsePolicy, Route, RoutingInfo, SingleNodeRoutingInfo,
             Slot, SlotAddr,
@@ -1276,6 +1276,317 @@ mod cluster_async {
     }
 
     #[test]
+    fn test_async_cluster_uniform_random_falls_back_after_selected_replica_io_error() {
+        let name = "async_uniform_random_fallback";
+        let slots_config = vec![MockSlotRange {
+            primary_port: 6379,
+            replica_ports: vec![6380, 6381],
+            slot_range: 0..16384,
+        }];
+        let ports = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let ports_clone = ports.clone();
+        let failed_once = Arc::new(AtomicBool::new(false));
+        let failed_once_clone = failed_once.clone();
+
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .retries(2)
+                .read_routing_strategy(UniformRandom::new()),
+            name,
+            move |cmd: &[u8], port| {
+                respond_startup_with_replica_using_config(name, cmd, Some(slots_config.clone()))?;
+
+                if contains_slice(cmd, b"GET") {
+                    ports_clone.lock().unwrap().push(port);
+                    if port != 6379 && !failed_once_clone.swap(true, Ordering::SeqCst) {
+                        return Err(Err(RedisError::from(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            "mock selected replica failure",
+                        ))));
+                    }
+                    return Err(Ok(redis_value!("123")));
+                }
+
+                Ok(())
+            },
+        );
+
+        let value = runtime.block_on(
+            cmd("GET")
+                .arg("test")
+                .query_async::<Option<i32>>(&mut connection),
+        );
+
+        assert_eq!(value, Ok(Some(123)));
+        let recorded = ports.lock().unwrap().clone();
+        assert_eq!(recorded.len(), 2);
+        assert_ne!(recorded[0], 6379);
+        assert_eq!(recorded[1], 6379);
+    }
+
+    #[test]
+    fn test_async_cluster_uniform_random_falls_back_when_selected_replica_cannot_connect() {
+        let name = "async_uniform_random_connect_fallback";
+        let slots_config = vec![MockSlotRange {
+            primary_port: 6379,
+            replica_ports: vec![6380, 6381],
+            slot_range: 0..16384,
+        }];
+        let read_ports = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let read_ports_clone = Arc::clone(&read_ports);
+        let replica_connect_attempts = Arc::new(AtomicUsize::new(0));
+        let replica_connect_attempts_clone = Arc::clone(&replica_connect_attempts);
+
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .retries(0)
+                .read_routing_strategy(UniformRandom::new()),
+            name,
+            move |cmd: &[u8], port| {
+                if contains_slice(cmd, b"READONLY") && port != 6379 {
+                    replica_connect_attempts_clone.fetch_add(1, Ordering::SeqCst);
+                    return Err(Err(RedisError::from(std::io::Error::new(
+                        std::io::ErrorKind::ConnectionRefused,
+                        "mock replica connect failure",
+                    ))));
+                }
+                respond_startup_with_replica_using_config(name, cmd, Some(slots_config.clone()))?;
+                if contains_slice(cmd, b"GET") {
+                    read_ports_clone.lock().unwrap().push(port);
+                    return Err(Ok(redis_value!("123")));
+                }
+                Ok(())
+            },
+        );
+
+        let attempts_after_startup = replica_connect_attempts.load(Ordering::SeqCst);
+        assert!(attempts_after_startup > 0);
+
+        for _ in 0..2 {
+            let value = runtime.block_on(
+                cmd("GET")
+                    .arg("test")
+                    .query_async::<Option<i32>>(&mut connection),
+            );
+            assert_eq!(value, Ok(Some(123)));
+        }
+
+        assert_eq!(*read_ports.lock().unwrap(), vec![6379, 6379]);
+        assert_eq!(
+            replica_connect_attempts.load(Ordering::SeqCst),
+            attempts_after_startup
+        );
+    }
+
+    #[test]
+    fn test_async_cluster_uniform_random_replica_required_connects_to_another_replica() {
+        let name = "async_uniform_random_replica_required_connect_fallback";
+        let slots_config = vec![MockSlotRange {
+            primary_port: 6379,
+            replica_ports: vec![6380, 6381],
+            slot_range: 0..16384,
+        }];
+        let failed_replica = Arc::new(AtomicU16::new(0));
+        let failed_replica_clone = Arc::clone(&failed_replica);
+        let read_ports = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let read_ports_clone = Arc::clone(&read_ports);
+
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .retries(0)
+                .read_routing_strategy(UniformRandom::new()),
+            name,
+            move |cmd: &[u8], port| {
+                if contains_slice(cmd, b"READONLY") && port != 6379 {
+                    let failed = failed_replica_clone
+                        .compare_exchange(0, port, Ordering::SeqCst, Ordering::SeqCst)
+                        .unwrap_or_else(|failed| failed);
+                    if failed == port || failed == 0 {
+                        return Err(Err(RedisError::from(std::io::Error::new(
+                            std::io::ErrorKind::ConnectionRefused,
+                            "mock selected replica connect failure",
+                        ))));
+                    }
+                }
+                respond_startup_with_replica_using_config(name, cmd, Some(slots_config.clone()))?;
+                if contains_slice(cmd, b"GET") {
+                    read_ports_clone.lock().unwrap().push(port);
+                    return Err(Ok(redis_value!("123")));
+                }
+                Ok(())
+            },
+        );
+
+        let failed_replica = failed_replica.load(Ordering::SeqCst);
+        assert!(matches!(failed_replica, 6380 | 6381));
+        let mut command = cmd("GET");
+        command.arg("test");
+        let value = runtime
+            .block_on(connection.route_command(
+                command,
+                RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(Route::with_key(
+                    "test",
+                    SlotAddr::ReplicaRequired,
+                ))),
+            ))
+            .unwrap();
+
+        assert_eq!(value, redis_value!("123"));
+        let read_ports = read_ports.lock().unwrap();
+        assert_eq!(read_ports.len(), 1);
+        assert_ne!(read_ports[0], 6379);
+        assert_ne!(read_ports[0], failed_replica);
+    }
+
+    #[test]
+    fn test_async_cluster_uniform_random_connects_to_one_replica_per_shard() {
+        let name = "async_uniform_random_connection_count";
+        let slots_config = vec![
+            MockSlotRange {
+                primary_port: 6379,
+                replica_ports: vec![6380, 6381],
+                slot_range: 0..8192,
+            },
+            MockSlotRange {
+                primary_port: 6382,
+                replica_ports: vec![6383, 6384],
+                slot_range: 8192..16384,
+            },
+        ];
+        let slot_refreshes = Arc::new(AtomicUsize::new(0));
+        let slot_refreshes_clone = Arc::clone(&slot_refreshes);
+        let async_connection_ports = Arc::new(std::sync::Mutex::new(HashSet::new()));
+        let async_connection_ports_clone = Arc::clone(&async_connection_ports);
+        let command_ports = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let command_ports_clone = Arc::clone(&command_ports);
+        let readonly_ports = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let readonly_ports_clone = Arc::clone(&readonly_ports);
+        let trigger_moved = Arc::new(AtomicBool::new(false));
+        let trigger_moved_clone = Arc::clone(&trigger_moved);
+
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .read_routing_strategy(UniformRandom::new()),
+            name,
+            move |cmd: &[u8], port| {
+                if contains_slice(cmd, b"READONLY") {
+                    readonly_ports_clone.lock().unwrap().push(port);
+                }
+                if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+                    slot_refreshes_clone.fetch_add(1, Ordering::SeqCst);
+                    return respond_startup_with_replica_using_config(
+                        name,
+                        cmd,
+                        Some(slots_config.clone()),
+                    );
+                }
+                if is_connection_check(cmd) && slot_refreshes_clone.load(Ordering::SeqCst) >= 2 {
+                    async_connection_ports_clone.lock().unwrap().insert(port);
+                }
+                respond_startup_with_replica_using_config(name, cmd, Some(slots_config.clone()))?;
+                if contains_slice(cmd, b"GET") {
+                    command_ports_clone.lock().unwrap().push(port);
+                    if trigger_moved_clone.swap(false, Ordering::SeqCst) {
+                        return Err(parse_redis_value(
+                            format!("-MOVED 6918 {name}:6379\r\n").as_bytes(),
+                        ));
+                    }
+                    return Err(Ok(Value::Nil));
+                }
+                Ok(())
+            },
+        );
+
+        let connected_ports = async_connection_ports.lock().unwrap().clone();
+        assert!(connected_ports.contains(&6379));
+        assert!(connected_ports.contains(&6382));
+        assert_eq!(
+            connected_ports
+                .iter()
+                .filter(|port| matches!(**port, 6380 | 6381))
+                .count(),
+            1
+        );
+        assert_eq!(
+            connected_ports
+                .iter()
+                .filter(|port| matches!(**port, 6383 | 6384))
+                .count(),
+            1
+        );
+        assert_eq!(connected_ports.len(), 4);
+
+        let omitted_replica = [6380, 6381, 6383, 6384]
+            .into_iter()
+            .find(|port| !connected_ports.contains(port))
+            .unwrap();
+        let mut get_command = cmd("GET");
+        get_command.arg("test");
+        runtime
+            .block_on(connection.route_command(
+                get_command.clone(),
+                RoutingInfo::SingleNode(SingleNodeRoutingInfo::ByAddress {
+                    host: name.to_string(),
+                    port: omitted_replica,
+                }),
+            ))
+            .unwrap();
+        assert_eq!(*command_ports.lock().unwrap(), vec![omitted_replica]);
+        command_ports.lock().unwrap().clear();
+
+        runtime
+            .block_on(connection.route_command(
+                get_command,
+                RoutingInfo::MultiNode((MultipleNodeRoutingInfo::AllNodes, None)),
+            ))
+            .unwrap();
+        command_ports.lock().unwrap().sort_unstable();
+        assert_eq!(
+            *command_ports.lock().unwrap(),
+            vec![6379, 6380, 6381, 6382, 6383, 6384]
+        );
+
+        trigger_moved.store(true, Ordering::SeqCst);
+        let _: Option<String> = runtime
+            .block_on(cmd("GET").arg("test").query_async(&mut connection))
+            .unwrap();
+        readonly_ports.lock().unwrap().clear();
+
+        let mut get_command = cmd("GET");
+        get_command.arg("test");
+        runtime
+            .block_on(connection.route_command(
+                get_command,
+                RoutingInfo::SingleNode(SingleNodeRoutingInfo::ByAddress {
+                    host: name.to_string(),
+                    port: omitted_replica,
+                }),
+            ))
+            .unwrap();
+        assert_eq!(*readonly_ports.lock().unwrap(), vec![omitted_replica]);
+    }
+
+    #[test]
     fn test_async_cluster_round_robin_read() {
         let name = "test_async_cluster_round_robin_read";
         let ports = Arc::new(std::sync::Mutex::new(Vec::new()));
@@ -1993,6 +2304,56 @@ mod cluster_async {
             .block_on(cmd.query_async::<Vec<String>>(&mut connection))
             .unwrap();
         assert_eq!(result, vec!["foo-6382", "bar-6380", "baz-6380"]);
+    }
+
+    #[test]
+    fn test_async_cluster_uniform_random_multi_shard_read_falls_back_to_primaries() {
+        let name = "async_uniform_random_multi_shard_fallback";
+        let replica_connect_attempts = Arc::new(AtomicUsize::new(0));
+        let replica_connect_attempts_clone = Arc::clone(&replica_connect_attempts);
+        let mut command = cmd("MGET");
+        command.arg("foo").arg("bar").arg("baz");
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .retries(0)
+                .read_routing_strategy(UniformRandom::new()),
+            name,
+            move |received_cmd: &[u8], port| {
+                if contains_slice(received_cmd, b"READONLY") && matches!(port, 6380 | 6382) {
+                    replica_connect_attempts_clone.fetch_add(1, Ordering::SeqCst);
+                    return Err(Err(RedisError::from(std::io::Error::new(
+                        std::io::ErrorKind::ConnectionRefused,
+                        "mock replica connect failure",
+                    ))));
+                }
+                respond_startup_with_replica_using_config(name, received_cmd, None)?;
+                let cmd_str = std::str::from_utf8(received_cmd).unwrap();
+                let results = ["foo", "bar", "baz"]
+                    .iter()
+                    .filter(|expected_key| cmd_str.contains(*expected_key))
+                    .map(|expected_key| redis_value!(format!("{expected_key}-{port}").into_bytes()))
+                    .collect();
+                Err(Ok(Value::Array(results)))
+            },
+        );
+
+        let attempts_after_startup = replica_connect_attempts.load(Ordering::SeqCst);
+        assert!(attempts_after_startup >= 2);
+        for _ in 0..2 {
+            let result = runtime
+                .block_on(command.query_async::<Vec<String>>(&mut connection))
+                .unwrap();
+            assert_eq!(result, vec!["foo-6381", "bar-6379", "baz-6379"]);
+        }
+        assert_eq!(
+            replica_connect_attempts.load(Ordering::SeqCst),
+            attempts_after_startup
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `UniformRandom`, a built-in cluster read strategy that gives each connection one stable, uniformly distributed replica choice per shard. The choice uses rendezvous hashing over a per-connection random seed and the shard's replicas, so it is independent of topology ordering and remaps only the affected shards when membership changes.

The important difference from the earlier version is that the strategy now controls connection selection as well as command routing. In normal keyed steady state the eager pool contains every primary and exactly one selected replica per shard, instead of opening connections to every replica and merely sampling among them later.

Existing read strategies retain their original hot path. The additional fallback and exclusion bookkeeping is specialized to `UniformRandom` so primary and `RandomReplicaStrategy` routing do not pay that cost.

Sync multi-slot commands now dispatch through the address selected during route splitting. Previously that path resolved the same route again for strategies without fallback, advancing stateful round-robin strategies twice per subrequest and causing an even-sized replica set to serve only half of its replicas. The selected address, actual connection, and response label now stay aligned.

## Connection behavior

- A replica-optional read uses the selected replica while it is connected. If it becomes unavailable, the request falls back to the primary without reconnecting to every replica; affinity is restored when the selected replica reconnects.
- A replica-required read remains replica-only and may try a different replica after the selected one fails.
- Request-scoped exclusions prevent immediate retries against a node that just failed, including I/O errors and reconnectable timeout errors.
- Topology refreshes rebuild the per-shard selection and prune omitted pooled nodes. Async `AllNodes` fanout uses transient connections for omitted nodes; sync fanout prunes connections it added afterward.
- Explicit-address, redirect, and failure recovery paths can temporarily add an on-demand connection, which is retained until the next topology refresh.
- Async redirect handling normalizes nested redirects back through current slot routing, and a generation guard prevents an in-flight stale connection from being reinserted after pruning.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked -p redis --all-features --all-targets -- -D warnings`
- `cargo check --locked --workspace --all-targets --all-features`
- `cargo +1.85.0 test -p redis --locked --all-features --lib` (222 passed)
- Full sync cluster suite (53 passed, 1 ignored)
- Focused sync and async `UniformRandom` suites (5 passed each)
- Async fanout coverage (14 passed)
- Complete-cluster disconnect and reconnecting route-to-many regressions under both Tokio and smol
- The sync cross-slot `MGET` regression fails on the pre-fix path with actual destinations `6381/6384` instead of `6380/6383`, and passes after the fix
- `RUSTFLAGS="-D warnings" cargo +1.85.0 bench -p redis --locked --all-features --bench bench_cluster --no-run`
- `RUSTFLAGS="-D warnings" cargo +1.85.0 bench -p redis --locked --all-features --bench bench_cluster_read_routing --no-run`
- `git diff --check`
- [GitHub Actions run 29365033185, attempt 2](https://github.com/chalk-ai/redis-rs/actions/runs/29365033185/attempts/2): 23/23 jobs passed

The real-cluster GET and pipeline groups for primary, `RandomReplicaStrategy`, and `UniformRandom` remain in `bench_cluster`; the deterministic mock benchmark covers routing overhead without network noise.

The current Windows runner exposes Visual Studio 18, which the previously locked `cmake` 0.1.54 build helper could not identify before compiling this crate. `Cargo.lock` now carries `cmake` 0.1.58 and its required `cc`/MSVC discovery updates; 0.1.58 explicitly supports the `Visual Studio 18 2026` generator and retains a Rust 1.65 minimum.

## Benchmark

Compared `origin/main` (`57bdc44`) with the initial candidate using Rust 1.85.0, identical release flags, and the exact Criterion mock-GET cases. Each result used 100 samples, a 2-second warm-up, and a 5-second measurement window.

| Strategy | `origin/main` median | Candidate median | Change |
| --- | ---: | ---: | ---: |
| Primary | 208.66 ns | 209.01 ns | +0.17% |
| `RandomReplicaStrategy` | 215.90 ns | 216.18 ns | +0.13% |
| `UniformRandom` | n/a | 216.34 ns | new strategy |

Criterion reported no performance change for the existing strategies. `UniformRandom` is effectively level with `RandomReplicaStrategy`; these numbers are regression evidence, not a speedup claim.

For the sync multi-slot follow-up, the benchmark source and inputs were held identical while toggling only the dispatch fix. The two-shard round-robin `MGET` baseline was 751.86 ns median. Three fixed runs measured 665.05 ns, 653.23 ns, and 668.19 ns; Criterion estimated 9.7% to 12.0% lower latency in all three runs. The gain comes from removing the duplicate slot-map lookup, strategy lock/read, atomic increment, and connection resolution for every subrequest.

## Env vars

None.
