### PR TITLE
fix(cluster): apply MOVED slot hints instead of refetching the whole map

### DIFF
--- a/redis/src/cluster_handling/client.rs
+++ b/redis/src/cluster_handling/client.rs
@@ -54,6 +54,23 @@ use crate::cluster_async;
 #[cfg(feature = "tls-rustls")]
 use crate::tls::{TlsCertificates, retrieve_tls_certificates};
 
+/// How long a connection waits between full `CLUSTER SLOTS` refreshes triggered
+/// by MOVED redirects.
+///
+/// A MOVED already tells the client which slot moved and where, and the sync
+/// client applies that directly (see [`SlotMap::update_slot`]), so the full
+/// refresh is no longer what keeps routing correct — it exists to pick up
+/// replica-set and node-set changes, and to compact a slot map that incremental
+/// updates have fragmented. Those tolerate tens of seconds of staleness.
+///
+/// Refreshing on *every* MOVED, as this client used to, is pathological during a
+/// resharding: `CLUSTER SLOTS` costs O(slot ranges), the slot map is at its most
+/// fragmented mid-reshard, and every pooled connection pays independently.
+/// Set to [`Duration::ZERO`] via
+/// [`ClusterClientBuilder::min_slot_refresh_interval`] to restore the old
+/// behaviour.
+const DEFAULT_MIN_SLOT_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
+
 /// Parameters specific to builder, so that
 /// builder parameters may have different types
 /// than final ClusterParams
@@ -69,6 +86,7 @@ struct BuilderParams {
     #[cfg(any(feature = "tls-rustls-insecure", feature = "tls-native-tls"))]
     danger_accept_invalid_hostnames: bool,
     retries_configuration: RetryParams,
+    min_slot_refresh_interval: Option<Duration>,
     connection_timeout: Option<Duration>,
     response_timeout: Option<Duration>,
     protocol: Option<ProtocolVersion>,
@@ -137,6 +155,7 @@ pub(crate) struct ClusterParams {
     /// When None, connections do not use tls.
     pub(crate) tls: Option<TlsMode>,
     pub(crate) retry_params: RetryParams,
+    pub(crate) min_slot_refresh_interval: Duration,
     pub(crate) tls_params: Option<TlsConnParams>,
     pub(crate) connection_timeout: Duration,
     pub(crate) response_timeout: Option<Duration>,
@@ -197,6 +216,9 @@ impl ClusterParams {
             client_name_factory: None,
             tls: value.tls,
             retry_params: value.retries_configuration,
+            min_slot_refresh_interval: value
+                .min_slot_refresh_interval
+                .unwrap_or(DEFAULT_MIN_SLOT_REFRESH_INTERVAL),
             tls_params,
             connection_timeout: value
                 .connection_timeout
@@ -379,6 +401,23 @@ impl ClusterClientBuilder {
     /// Sets number of retries for the new ClusterClient.
     pub fn retries(mut self, retries: u32) -> ClusterClientBuilder {
         self.builder_params.retries_configuration.number_of_retries = retries;
+        self
+    }
+
+    /// Sets the minimum time between MOVED-triggered `CLUSTER SLOTS` refreshes.
+    ///
+    /// Defaults to 30 seconds. A MOVED redirect updates the affected slot in the
+    /// local map directly, so this only bounds how often the *whole* map is
+    /// refetched. The actual wait is jittered around this value so that a pool of
+    /// connections created together does not refresh in lockstep.
+    ///
+    /// [`Duration::ZERO`] refreshes on every MOVED, which is the historical
+    /// behaviour and is very expensive against a resharding cluster.
+    ///
+    /// This does not affect refreshes triggered by anything other than a MOVED —
+    /// a lost connection still refreshes immediately.
+    pub fn min_slot_refresh_interval(mut self, interval: Duration) -> ClusterClientBuilder {
+        self.builder_params.min_slot_refresh_interval = Some(interval);
         self
     }
 

--- a/redis/src/cluster_handling/slot_map.rs
+++ b/redis/src/cluster_handling/slot_map.rs
@@ -42,6 +42,60 @@ impl SlotMap {
         }
     }
 
+    /// Point a single slot at `primary`, splitting whatever range covers it.
+    ///
+    /// A `MOVED <slot> <addr>` reply carries exactly the information a full
+    /// `CLUSTER SLOTS` would have supplied *for that one slot*, so this lets the
+    /// caller repair its map from the redirect it already received instead of
+    /// refetching all 16384 mappings.
+    ///
+    /// Splitting rather than overwriting is load-bearing. [`SlotRangeMap`] is
+    /// keyed on range *end*, so inserting `[slot, slot]` into the middle of
+    /// `[a, b]` without re-inserting `[a, slot - 1]` would leave every slot
+    /// below `slot` resolving to `None` — silently unrouted, not merely stale.
+    ///
+    /// Only ever call this for MOVED. An ASK redirect is a per-key, per-request
+    /// instruction for a slot that is still mid-migration and still owned by the
+    /// source node; recording it here would send that slot's not-yet-migrated
+    /// keys to a node that does not serve them.
+    pub(crate) fn update_slot(&mut self, slot: u16, primary: NodeAddress) {
+        // Replicas are a property of the shard, not of the individual slot: every
+        // range a given primary owns reports the same replica set. Carrying that
+        // set over keeps replica reads working for this slot instead of pinning
+        // them to the primary until the next full refresh. The scan is O(ranges)
+        // and only runs on a redirect; a denormalised primary→replicas cache
+        // would be faster but would have to be kept consistent in every place
+        // that builds a map, which is more room for error than it is worth.
+        let replicas = self
+            .slots
+            .values()
+            .find(|addrs| addrs.primary == primary)
+            .map(|addrs| addrs.replicas.clone())
+            .unwrap_or_default();
+
+        let Some((start, end)) = self.slots.range_containing(slot) else {
+            self.slots
+                .insert(slot, slot, SlotAddrs::new(primary, replicas));
+            return;
+        };
+        let Some((_, old)) = self.slots.remove_range(end) else {
+            return;
+        };
+        if start < slot {
+            self.slots.insert(
+                start,
+                slot - 1,
+                SlotAddrs::new(old.primary.clone(), old.replicas.clone()),
+            );
+        }
+        if slot < end {
+            self.slots
+                .insert(slot + 1, end, SlotAddrs::new(old.primary, old.replicas));
+        }
+        self.slots
+            .insert(slot, slot, SlotAddrs::new(primary, replicas));
+    }
+
     pub fn slot_addr_for_route(
         &self,
         route: &Route,
@@ -289,6 +343,138 @@ mod tests {
 
     fn addr(s: &str) -> NodeAddress {
         NodeAddress::try_from(s).unwrap()
+    }
+
+    fn primary_for(map: &SlotMap, slot: u16) -> Option<String> {
+        map.slot_addr_for_route(&Route::new(slot, SlotAddr::Master), None)
+            .map(|a| a.to_string())
+    }
+
+    fn replica_for(map: &SlotMap, slot: u16) -> Option<String> {
+        map.slot_addr_for_route(&Route::new(slot, SlotAddr::ReplicaRequired), None)
+            .map(|a| a.to_string())
+    }
+
+    /// n1 owns 0-999, n2 owns 1000-1999, n3 owns 2000-2999, each with one replica.
+    fn three_shards() -> SlotMap {
+        SlotMap::from_slots(vec![
+            SlotRange::new(0, 999, addr("n1:6379"), vec![addr("r1:6379")]),
+            SlotRange::new(1000, 1999, addr("n2:6379"), vec![addr("r2:6379")]),
+            SlotRange::new(2000, 2999, addr("n3:6379"), vec![addr("r3:6379")]),
+        ])
+    }
+
+    #[test]
+    fn update_slot_splits_a_range_without_orphaning_its_neighbours() {
+        let mut map = three_shards();
+        map.update_slot(1500, addr("n3:6379"));
+
+        assert_eq!(primary_for(&map, 1500).as_deref(), Some("n3:6379"));
+        // Both halves of the split range must still resolve to the old owner. This
+        // is the regression the range-end keying invites.
+        for slot in [1000, 1234, 1499, 1501, 1800, 1999] {
+            assert_eq!(
+                primary_for(&map, slot).as_deref(),
+                Some("n2:6379"),
+                "slot {slot} lost its mapping"
+            );
+        }
+        assert_eq!(primary_for(&map, 999).as_deref(), Some("n1:6379"));
+        assert_eq!(primary_for(&map, 2000).as_deref(), Some("n3:6379"));
+    }
+
+    #[test]
+    fn update_slot_handles_both_range_edges() {
+        let mut map = three_shards();
+        map.update_slot(1000, addr("n1:6379"));
+        assert_eq!(primary_for(&map, 1000).as_deref(), Some("n1:6379"));
+        assert_eq!(primary_for(&map, 1001).as_deref(), Some("n2:6379"));
+        assert_eq!(primary_for(&map, 999).as_deref(), Some("n1:6379"));
+
+        let mut map = three_shards();
+        map.update_slot(1999, addr("n1:6379"));
+        assert_eq!(primary_for(&map, 1999).as_deref(), Some("n1:6379"));
+        assert_eq!(primary_for(&map, 1998).as_deref(), Some("n2:6379"));
+        assert_eq!(primary_for(&map, 2000).as_deref(), Some("n3:6379"));
+    }
+
+    #[test]
+    fn update_slot_inherits_the_new_primarys_replicas() {
+        let mut map = three_shards();
+        map.update_slot(1500, addr("n3:6379"));
+        // n3's replica is known from the range it already owns, so replica reads
+        // for the moved slot keep working instead of falling back to the primary.
+        assert_eq!(replica_for(&map, 1500).as_deref(), Some("r3:6379"));
+        assert_eq!(replica_for(&map, 1501).as_deref(), Some("r2:6379"));
+    }
+
+    #[test]
+    fn update_slot_to_an_unknown_node_falls_back_to_the_primary() {
+        let mut map = three_shards();
+        map.update_slot(1500, addr("new:6379"));
+        assert_eq!(primary_for(&map, 1500).as_deref(), Some("new:6379"));
+        // No replica set is knowable for a node that owns nothing else yet;
+        // reads must degrade to the primary rather than to a stale replica.
+        assert_eq!(replica_for(&map, 1500).as_deref(), Some("new:6379"));
+    }
+
+    #[test]
+    fn repeated_updates_keep_every_slot_correctly_mapped() {
+        let mut map = three_shards();
+        let mut expected: Vec<&str> = (0..3000u16)
+            .map(|slot| {
+                if slot < 1000 {
+                    "n1:6379"
+                } else if slot < 2000 {
+                    "n2:6379"
+                } else {
+                    "n3:6379"
+                }
+            })
+            .collect();
+
+        // Walk a pseudo-random sequence of slots to new owners, then assert the
+        // whole keyspace. A split that drops a neighbour would show up here as a
+        // silently misrouted slot rather than as an error.
+        let mut state: u64 = 7;
+        for i in 0..1000 {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            let slot = ((state >> 33) % 3000) as u16;
+            let owner = if i % 2 == 0 { "n1:6379" } else { "nX:6379" };
+            map.update_slot(slot, addr(owner));
+            expected[slot as usize] = owner;
+        }
+        for (slot, want) in expected.iter().enumerate() {
+            assert_eq!(
+                primary_for(&map, slot as u16).as_deref(),
+                Some(*want),
+                "slot {slot} misrouted"
+            );
+        }
+    }
+
+    #[test]
+    fn update_slot_on_an_empty_map_inserts_a_single_slot() {
+        let mut map = SlotMap::new();
+        map.update_slot(42, addr("n1:6379"));
+        assert_eq!(primary_for(&map, 42).as_deref(), Some("n1:6379"));
+        assert_eq!(primary_for(&map, 43), None);
+    }
+
+    #[test]
+    fn a_full_refresh_discards_incremental_updates() {
+        let mut map = three_shards();
+        map.update_slot(1500, addr("n3:6379"));
+        // A later CLUSTER SLOTS is authoritative and must win, including undoing
+        // an update that has since become wrong.
+        map = SlotMap::from_slots(vec![
+            SlotRange::new(0, 999, addr("n1:6379"), vec![addr("r1:6379")]),
+            SlotRange::new(1000, 1999, addr("n2:6379"), vec![addr("r2:6379")]),
+            SlotRange::new(2000, 2999, addr("n3:6379"), vec![addr("r3:6379")]),
+        ]);
+        assert_eq!(primary_for(&map, 1500).as_deref(), Some("n2:6379"));
     }
 
     /// Always picks the first replica.

--- a/redis/src/cluster_handling/slot_range_map.rs
+++ b/redis/src/cluster_handling/slot_range_map.rs
@@ -28,6 +28,19 @@ impl<V> SlotRangeMap<V> {
         )
     }
 
+    /// Bounds of the range containing `slot`, if any.
+    pub fn range_containing(&self, slot: u16) -> Option<(u16, u16)> {
+        self.inner
+            .range(slot..)
+            .next()
+            .and_then(|(&end, (start, _))| (slot >= *start).then_some((*start, end)))
+    }
+
+    /// Remove the range ending at `end`, returning its start and value.
+    pub fn remove_range(&mut self, end: u16) -> Option<(u16, V)> {
+        self.inner.remove(&end)
+    }
+
     /// Iterate over all values (one per range entry, in slot order).
     pub fn values(&self) -> impl Iterator<Item = &V> {
         self.inner.values().map(|(_, v)| v)
@@ -77,6 +90,32 @@ mod tests {
         assert_eq!(m.get(99), None);
         assert_eq!(m.get(250), None);
         assert_eq!(m.get(401), None);
+    }
+
+    #[test]
+    fn range_containing_reports_bounds_or_none() {
+        let mut m = SlotRangeMap::new();
+        m.insert(100, 200, "a");
+        m.insert(300, 400, "b");
+
+        assert_eq!(m.range_containing(100), Some((100, 200)));
+        assert_eq!(m.range_containing(150), Some((100, 200)));
+        assert_eq!(m.range_containing(200), Some((100, 200)));
+        assert_eq!(m.range_containing(400), Some((300, 400)));
+        assert_eq!(m.range_containing(250), None);
+        assert_eq!(m.range_containing(401), None);
+    }
+
+    #[test]
+    fn remove_range_takes_the_entry_by_end() {
+        let mut m = SlotRangeMap::new();
+        m.insert(100, 200, "a");
+        m.insert(300, 400, "b");
+
+        assert_eq!(m.remove_range(200), Some((100, "a")));
+        assert_eq!(m.get(150), None);
+        assert_eq!(m.get(350), Some(&"b"));
+        assert_eq!(m.remove_range(200), None);
     }
 
     #[test]

--- a/redis/src/cluster_handling/sync_connection/mod.rs
+++ b/redis/src/cluster_handling/sync_connection/mod.rs
@@ -66,7 +66,7 @@ use std::cell::RefCell;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use arcstr::ArcStr;
 
@@ -100,7 +100,7 @@ use crate::errors::{ErrorKind, RedisError, RetryMethod};
 use crate::parser::parse_redis_value;
 use crate::types::{HashMap, RedisResult, Value};
 use pipeline::UNROUTABLE_ERROR;
-use rand::{rng, seq::IteratorRandom};
+use rand::{Rng, rng, seq::IteratorRandom};
 
 pub use pipeline::{ClusterPipeline, cluster_pipe};
 
@@ -334,6 +334,10 @@ pub struct ClusterConnection<C = Connection> {
     routing_strategy: Option<Box<dyn ReadRoutingStrategy>>,
     read_fallback_enabled: bool,
     az_discovery: Arc<NodeAvailabilityZoneDiscoveryState>,
+    /// Earliest instant at which a rate-limited caller may refetch the whole slot
+    /// map. `None` means one is allowed now. See
+    /// [`Self::refresh_slots_rate_limited`].
+    next_slot_refresh: RefCell<Option<Instant>>,
     cluster_params: ClusterParams,
 }
 
@@ -394,6 +398,7 @@ where
             routing_strategy,
             read_fallback_enabled,
             az_discovery: Arc::new(NodeAvailabilityZoneDiscoveryState::default()),
+            next_slot_refresh: RefCell::new(None),
             initial_nodes: initial_nodes.to_vec(),
             cluster_params,
         };
@@ -530,8 +535,51 @@ where
         Ok(())
     }
 
+    /// Refreshes the whole slot map, unless one was refreshed recently.
+    ///
+    /// Only for callers that have another way to reach the right node — a MOVED
+    /// whose hint has already been recorded by [`SlotMap::update_slot`], or a
+    /// retry that will follow its own redirect. For those, refetching all 16384
+    /// mappings is not what makes the request correct; it only refreshes replica
+    /// sets, picks up nodes joining or leaving, and compacts a map that
+    /// incremental updates have split. Skipping it costs at worst one extra
+    /// redirect on some *other* slot that also moved, which is far cheaper than
+    /// the `CLUSTER SLOTS` it saves on a fragmented cluster.
+    ///
+    /// Callers with no other recovery path must use [`Self::refresh_slots`].
+    fn refresh_slots_rate_limited(&self) -> RedisResult<()> {
+        if !self.cluster_params.min_slot_refresh_interval.is_zero() {
+            if let Some(next) = *self.next_slot_refresh.borrow() {
+                if Instant::now() < next {
+                    return Ok(());
+                }
+            }
+        }
+        self.refresh_slots()
+    }
+
+    /// Arms the deadline checked by [`Self::refresh_slots_rate_limited`].
+    ///
+    /// Every full refresh arms it, whatever triggered it, because the thing being
+    /// rate-limited is refetching the whole map — a MOVED arriving just after a
+    /// reconnect-driven refresh has nothing new to learn. Arming it *before* the
+    /// refresh runs also means a slow or failing refresh cannot be re-entered in a
+    /// tight loop by the redirects that arrive while it is in flight.
+    fn arm_slot_refresh_deadline(&self) {
+        let interval = self.cluster_params.min_slot_refresh_interval;
+        if interval.is_zero() {
+            return;
+        }
+        // Jittered because pooled connections are typically constructed together:
+        // an exact interval keeps their deadlines in phase and turns a steady
+        // trickle of refreshes into a synchronised burst.
+        let jitter = rng().random_range(0.5..1.5);
+        *self.next_slot_refresh.borrow_mut() = Some(Instant::now() + interval.mul_f64(jitter));
+    }
+
     // Query a node to discover slot-> master mappings.
     fn refresh_slots(&self) -> RedisResult<()> {
+        self.arm_slot_refresh_deadline();
         let mut new_slots = self.create_new_slots()?;
 
         if let Some(ref strategy) = self.routing_strategy {
@@ -1463,12 +1511,36 @@ where
                             });
                         }
                         RetryMethod::MovedRedirect => {
-                            // Refresh slots.
-                            self.refresh_slots()?;
-                            // Request again.
-                            redirected = err.redirect_node().and_then(|(node, _slot)| {
-                                NodeAddress::try_from(node).ok().map(Redirect::Moved)
+                            let moved_to = err.redirect_node().and_then(|(node, slot)| {
+                                NodeAddress::try_from(node).ok().map(|addr| (addr, slot))
                             });
+                            match moved_to {
+                                Some((addr, slot)) => {
+                                    // A MOVED is authoritative about one slot's new
+                                    // owner, so record it instead of discarding it and
+                                    // asking the cluster to describe all 16384 slots
+                                    // again. This arm is MOVED-only: the ASK arm below
+                                    // must never do this, because an ASK slot is still
+                                    // owned by the node that issued the redirect.
+                                    //
+                                    // The borrow is scoped to this statement so it ends
+                                    // before the refresh borrows `slots` again.
+                                    self.slots.borrow_mut().update_slot(slot, addr.clone());
+                                    // Having learned the mapping first-hand, the full
+                                    // refresh is now only about replica and node-set
+                                    // freshness, so it is safe to rate limit.
+                                    self.refresh_slots_rate_limited()?;
+                                    redirected = Some(Redirect::Moved(addr));
+                                }
+                                None => {
+                                    // A redirect we cannot parse teaches us nothing and
+                                    // leaves us no node to retry against, so the full
+                                    // refresh is the only way to make progress. Never
+                                    // rate limit this one.
+                                    self.refresh_slots()?;
+                                    redirected = None;
+                                }
+                            }
                         }
                         RetryMethod::WaitAndRetry => {
                             // Sleep and retry.
@@ -1540,8 +1612,11 @@ where
             return Ok(results);
         }
 
-        // Refresh the slots to ensure that we have a clean slate for the retry attempts.
-        self.refresh_slots()?;
+        // Refresh the slots to give the retry attempts a clean slate. Rate limited
+        // because it is an optimisation rather than the recovery mechanism: each
+        // command below is retried through `request`, which follows its own
+        // redirects and falls back to an unthrottled refresh when it cannot.
+        self.refresh_slots_rate_limited()?;
 
         // Given that there are commands that need to be retried, it means something in the cluster
         // topology changed. Execute each command separately to take advantage of the existing

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -540,6 +540,239 @@ mod cluster {
         assert_eq!(value, Ok(vec!["OK".to_string(), "val1".to_string()]));
     }
 
+    /// CRC16("test") % 16384, i.e. the slot `GET test` routes to. Owned by 6379
+    /// under `respond_startup_two_nodes`.
+    const TEST_KEY_SLOT: u16 = 6918;
+
+    #[test]
+    fn test_cluster_moved_updates_slot_map_without_a_full_refresh() {
+        let name = "moved_updates_slot_map";
+        let slot_refreshes = Arc::new(atomic::AtomicUsize::new(0));
+        let moveds = Arc::new(atomic::AtomicUsize::new(0));
+        let requests_to_6380 = Arc::new(atomic::AtomicUsize::new(0));
+
+        let MockEnv {
+            mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                // Long enough that only the connection-time refresh may run, so
+                // anything the client still routes correctly it learned from the
+                // MOVED itself rather than from a refetched map.
+                .min_slot_refresh_interval(std::time::Duration::from_secs(3600)),
+            name,
+            {
+                let slot_refreshes = slot_refreshes.clone();
+                let moveds = moveds.clone();
+                let requests_to_6380 = requests_to_6380.clone();
+                move |cmd: &[u8], port| {
+                    if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+                        slot_refreshes.fetch_add(1, Ordering::SeqCst);
+                    }
+                    respond_startup_two_nodes(name, cmd)?;
+                    match port {
+                        // 6379 still believes it owns the slot and always redirects.
+                        6379 => {
+                            moveds.fetch_add(1, Ordering::SeqCst);
+                            Err(parse_redis_value(
+                                format!("-MOVED {TEST_KEY_SLOT} {name}:6380\r\n").as_bytes(),
+                            ))
+                        }
+                        6380 => {
+                            requests_to_6380.fetch_add(1, Ordering::SeqCst);
+                            Err(Ok(redis_value!("123")))
+                        }
+                        _ => panic!("Wrong node"),
+                    }
+                }
+            },
+        );
+
+        let refreshes_after_connect = slot_refreshes.load(Ordering::SeqCst);
+
+        assert_eq!(
+            cmd("GET").arg("test").query::<Option<i32>>(&mut connection),
+            Ok(Some(123))
+        );
+        assert_eq!(moveds.load(Ordering::SeqCst), 1);
+
+        // Every later request for the same slot must go straight to the new owner.
+        for _ in 0..5 {
+            assert_eq!(
+                cmd("GET").arg("test").query::<Option<i32>>(&mut connection),
+                Ok(Some(123))
+            );
+        }
+        assert_eq!(
+            moveds.load(Ordering::SeqCst),
+            1,
+            "slot map did not learn the new owner from the MOVED"
+        );
+        assert_eq!(requests_to_6380.load(Ordering::SeqCst), 6);
+        assert_eq!(
+            slot_refreshes.load(Ordering::SeqCst),
+            refreshes_after_connect,
+            "MOVED triggered a full CLUSTER SLOTS despite the refresh interval"
+        );
+    }
+
+    #[test]
+    fn test_cluster_ask_does_not_update_slot_map() {
+        let name = "ask_does_not_update_slot_map";
+        let asks = Arc::new(atomic::AtomicUsize::new(0));
+
+        let MockEnv {
+            mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .min_slot_refresh_interval(std::time::Duration::from_secs(3600)),
+            name,
+            {
+                let asks = asks.clone();
+                move |cmd: &[u8], port| {
+                    respond_startup_two_nodes(name, cmd)?;
+                    match port {
+                        6379 => {
+                            asks.fetch_add(1, Ordering::SeqCst);
+                            Err(parse_redis_value(
+                                format!("-ASK {TEST_KEY_SLOT} {name}:6380\r\n").as_bytes(),
+                            ))
+                        }
+                        6380 => {
+                            if contains_slice(cmd, b"ASKING") {
+                                Err(Ok(Value::Okay))
+                            } else {
+                                Err(Ok(redis_value!("123")))
+                            }
+                        }
+                        _ => panic!("Wrong node"),
+                    }
+                }
+            },
+        );
+
+        // An ASK is a one-request instruction about a slot that is still owned by
+        // the node issuing it, so it must not be recorded in the slot map. If it
+        // were, this slot's not-yet-migrated keys would be sent to a node that
+        // does not serve them. Every request must therefore still start at 6379.
+        for i in 1..=5 {
+            assert_eq!(
+                cmd("GET").arg("test").query::<Option<i32>>(&mut connection),
+                Ok(Some(123))
+            );
+            assert_eq!(
+                asks.load(Ordering::SeqCst),
+                i,
+                "an ASK redirect was written into the slot map"
+            );
+        }
+    }
+
+    #[test]
+    fn test_cluster_moved_without_an_address_still_forces_a_refresh() {
+        let name = "moved_without_address";
+        let slot_refreshes = Arc::new(atomic::AtomicUsize::new(0));
+        let started = Arc::new(atomic::AtomicBool::new(false));
+        let requests = Arc::new(atomic::AtomicUsize::new(0));
+
+        let MockEnv {
+            mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .min_slot_refresh_interval(std::time::Duration::from_secs(3600)),
+            name,
+            {
+                let slot_refreshes = slot_refreshes.clone();
+                let started = started.clone();
+                let requests = requests.clone();
+                move |cmd: &[u8], port| {
+                    if !started.load(Ordering::SeqCst) {
+                        respond_startup(name, cmd)?;
+                    }
+                    started.store(true, Ordering::SeqCst);
+                    if is_connection_check(cmd) {
+                        return Err(Ok(redis_value!(simple:"OK")));
+                    }
+                    match requests.fetch_add(1, Ordering::SeqCst) {
+                        // A MOVED carrying no address: nothing to record, and no node
+                        // to redirect to.
+                        0 => Err(parse_redis_value(b"-MOVED 123\r\n")),
+                        1 => {
+                            slot_refreshes.fetch_add(1, Ordering::SeqCst);
+                            Err(Ok(redis_value!([
+                                [0, 1, [name, 6379]],
+                                [2, 16383, [name, 6380]]
+                            ])))
+                        }
+                        _ => {
+                            assert_eq!(port, 6380);
+                            Err(Ok(redis_value!("123")))
+                        }
+                    }
+                }
+            },
+        );
+
+        // The refresh interval must not apply here. Rate limiting is only earned by
+        // having learned the mapping from the redirect itself; when the redirect is
+        // unusable, a full refresh is the only way the client can make progress, and
+        // throttling it strands the request until retries run out.
+        assert_eq!(
+            cmd("GET").arg("test").query::<Option<i32>>(&mut connection),
+            Ok(Some(123))
+        );
+        assert_eq!(slot_refreshes.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn test_cluster_zero_refresh_interval_refreshes_on_every_moved() {
+        let name = "zero_refresh_interval";
+        let slot_refreshes = Arc::new(atomic::AtomicUsize::new(0));
+
+        let MockEnv {
+            mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .min_slot_refresh_interval(std::time::Duration::ZERO),
+            name,
+            {
+                let slot_refreshes = slot_refreshes.clone();
+                move |cmd: &[u8], port| {
+                    if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+                        slot_refreshes.fetch_add(1, Ordering::SeqCst);
+                    }
+                    respond_startup_two_nodes(name, cmd)?;
+                    match port {
+                        6379 => Err(parse_redis_value(
+                            format!("-MOVED {TEST_KEY_SLOT} {name}:6380\r\n").as_bytes(),
+                        )),
+                        6380 => Err(Ok(redis_value!("123"))),
+                        _ => panic!("Wrong node"),
+                    }
+                }
+            },
+        );
+
+        // The escape hatch back to the historical behaviour has to keep working:
+        // the refreshed map re-points the slot at 6379, so each request MOVEDs
+        // again and each MOVED refetches the whole map.
+        let before = slot_refreshes.load(Ordering::SeqCst);
+        for _ in 0..3 {
+            assert_eq!(
+                cmd("GET").arg("test").query::<Option<i32>>(&mut connection),
+                Ok(Some(123))
+            );
+        }
+        assert_eq!(slot_refreshes.load(Ordering::SeqCst) - before, 3);
+    }
+
     #[test]
     fn test_cluster_ask_redirect() {
         let name = "test_cluster_ask_redirect";


### PR DESCRIPTION
## The problem

The sync cluster client throws away the slot number in a `MOVED` redirect and issues a full `CLUSTER SLOTS` instead — once per redirect, per pooled connection, with no rate limiting at all. There is no debounce, no last-refresh timestamp, and no config-epoch check anywhere in `cluster_handling/`.

That is pathological against a resharding cluster, because `CLUSTER SLOTS` costs O(slot ranges) and the slot map is at its most fragmented precisely mid-reshard. Measured on a 6-node cluster, rebuilding the map at each fragmentation level:

| Slot map | Ranges | usec/call | Reply bytes |
|---|---|---|---|
| Fresh cluster | 7 | 13.3 | 637 |
| Mid-reshard | 512 | 81.2 | 46,663 |
| Mid-reshard | 2,048 | 278.6 | 186,661 |
| Every slot split | 16,384 | 1,953.8 | 1,493,299 |

A `GET` on the same box is 0.73 usec. Under a live reshard at 1,024 pooled connections and 51k GET/s, `CLUSTER SLOTS` reached **30% of all command CPU** across the cluster and **47 MB/s** of egress, while the useful workload never changed. The MOVED-to-`CLUSTER SLOTS` ratio is exactly 1:1, and each refresh also PINGs every node.

## The change

A `MOVED` already names the slot and its new owner, so record it via `SlotMap::update_slot` and demote the full refresh to a jittered floor (`min_slot_refresh_interval`, default 30s). Following the redirect is what makes the in-flight command correct; the refresh only picks up replica-set and node-set changes and compacts a map that incremental updates have split — all of which tolerate tens of seconds of staleness.

`update_slot` splits the containing range rather than overwriting it. `SlotRangeMap` is keyed on range *end*, so inserting `[slot, slot]` into the middle of `[a, b]` without re-inserting `[a, slot-1]` would leave every slot below it resolving to `None` — silently unrouted, not merely stale.

The jitter matters: pooled connections are typically constructed together, so an exact interval keeps their deadlines in phase and converts a steady trickle of refreshes into a synchronised burst. I saw that thundering herd in an unjittered prototype.

The pipeline retry path is rate limited too, since each command there is retried through `request`, which follows its own redirects.

## Why this is safe

The slot map is a routing cache, not a correctness mechanism. A wrong entry costs one extra hop and never a wrong answer, because a node checks slot ownership and returns `MOVED` rather than serving a slot it does not own. The hint can only make the map more correct than it was — it replaces an entry pointing at a node that has definitively disowned the slot.

Two rules carry the safety, and both are enforced by tests:

- **Only `MOVED` updates the map.** An `ASK` names a slot that is still owned by the node issuing it and still mid-migration, so recording it would send that slot's not-yet-migrated keys to a node that does not serve them. Worth noting that `redirect_node()` returns `Some` for `ASK` *and* `MOVED`, so this is easy to get wrong.
- **A redirect we cannot parse still forces an unthrottled refresh.** With no usable address there is nothing to record and no node to retry against, so a full refresh is the only way to make progress. Throttling it strands the request until retries run out — this broke `test_cluster_move_error_when_new_node_is_added` and `test_cluster_client_name_factory_names_new_nodes_after_refresh` in an earlier revision, which is how it was caught.

One deliberate trade-off: a hinted slot inherits the new primary's replica set by looking it up from another range that node already owns. For a brand-new node that is unknown, so reads for that slot fall back to the primary until the next full refresh. Correct, but with `read_from_replicas` plus zonal routing it can mean briefly cross-AZ reads.

## Results

Real 6-node cluster under real slot migrations (the full `IMPORTING`/`MIGRATING`/`GETKEYSINSLOT`/`MIGRATE`/`SETSLOT` handshake), 1,024 pooled connections, compared over a matched 600–1300 slot ranges so churn-rate variance between runs cannot skew it:

| | before | after |
|---|---|---|
| GET/s served | 51,156 | 51,254 |
| Errors | 0 | 0 |
| CLUSTER SLOTS/s | 165.4 | **21.5** |
| PING/s | 992.5 | **128.5** |
| Egress MB/s | 16.2 | **2.6** |
| MOVED/s | 166 | 910 |

The extra redirects are the intended trade: a MOVED costs ~5 usec, the `CLUSTER SLOTS` it replaces ~182 usec at this fragmentation. Cluster CPU came out within noise over this particular window on a loaded box; the command-count and egress figures are the solid ones.

`ClusterClientBuilder::min_slot_refresh_interval(Duration::ZERO)` restores the previous behaviour, and there is a test asserting it does.

## Note for reviewers

**This changes the default behaviour** for every consumer of the fork. Happy to default it to `ZERO` and have callers opt in instead, if that is preferred.

Not included here: the same defect exists in the async client (identical discarded `_slot` in `async_connection/request.rs`), which would reuse `SlotMap::update_slot` directly. Its blast radius is much smaller because it holds one slot map per client rather than per connection. Bumping the `chalk-private` pin is also a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJRG1i7JVUG6HMkyDN8H3N
